### PR TITLE
Move slog to an interface

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,8 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gover: ["1.21"]
-        # gover: ["1.19", "1.20", "1.21"] # TODO: move slog to version specific files, make it a noop for older versions
+        gover: ["1.19", "1.20", "1.21"]
 
     env:
       RELEASE_GO_VER: "1.21"

--- a/cmd/olareg/olareg_1.21.go
+++ b/cmd/olareg/olareg_1.21.go
@@ -1,0 +1,27 @@
+//go:build go1.21
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+)
+
+func setupLogFlag(newCmd *cobra.Command, opts *rootOpts) {
+	newCmd.PersistentFlags().StringVarP(&opts.levelStr, "verbosity", "v", "warn", "Log level (debug, info, warn, error)")
+	_ = newCmd.RegisterFlagCompletionFunc("verbosity", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"debug", "info", "warn", "error"}, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
+func setupLogger(cmd *cobra.Command, opts *rootOpts) error {
+	var lvl slog.Level
+	err := lvl.UnmarshalText([]byte(opts.levelStr))
+	if err != nil {
+		return fmt.Errorf("unable to parse verbosity %s: %v", opts.levelStr, err)
+	}
+	opts.log = slog.New(slog.NewTextHandler(cmd.ErrOrStderr(), &slog.HandlerOptions{Level: lvl}))
+	return nil
+}

--- a/cmd/olareg/olareg_old.go
+++ b/cmd/olareg/olareg_old.go
@@ -1,0 +1,15 @@
+//go:build !go1.21
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Empty functions since log/slog is not provided in older versions of go.
+
+func setupLogFlag(newCmd *cobra.Command, opts *rootOpts) {}
+
+func setupLogger(cmd *cobra.Command, opts *rootOpts) error {
+	return nil
+}

--- a/config.go
+++ b/config.go
@@ -2,8 +2,9 @@ package olareg
 
 import (
 	"fmt"
-	"log/slog"
 	"strings"
+
+	"github.com/olareg/olareg/internal/slog"
 )
 
 // TODO: add config struct
@@ -19,7 +20,7 @@ const (
 type Config struct {
 	StoreType Store
 	RootDir   string
-	Log       *slog.Logger
+	Log       slog.Logger
 	// TODO: TLS and listener options? not needed here if only providing handler
 	// TODO: GC policy, delete untagged? timeouts for partial blobs?
 	// TODO: proxy settings, pull only, or push+pull cache

--- a/internal/slog/slog.go
+++ b/internal/slog/slog.go
@@ -1,0 +1,17 @@
+// Package slog is a temporary interface to support older versions of Go.
+package slog
+
+type Logger interface {
+	Debug(msg string, args ...any)
+	Error(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+}
+
+// Null is a logger that does nothing.
+type Null struct{}
+
+func (n Null) Debug(msg string, args ...any) {}
+func (n Null) Error(msg string, args ...any) {}
+func (n Null) Info(msg string, args ...any)  {}
+func (n Null) Warn(msg string, args ...any)  {}

--- a/internal/store/dir.go
+++ b/internal/store/dir.go
@@ -3,7 +3,6 @@ package store
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 
+	"github.com/olareg/olareg/internal/slog"
 	"github.com/olareg/olareg/types"
 )
 
@@ -38,7 +38,7 @@ type dir struct {
 	mu    sync.Mutex
 	root  string
 	repos map[string]*dirRepo // TODO: switch to storing these in a cache that expires from memory
-	log   *slog.Logger
+	log   slog.Logger
 }
 
 type dirRepo struct {
@@ -51,7 +51,7 @@ type dirRepo struct {
 	index     types.Index
 	tags      map[string]types.Descriptor
 	manifests map[digest.Digest]types.Descriptor
-	log       *slog.Logger
+	log       slog.Logger
 }
 
 // OptDir includes options for the directory store.
@@ -67,14 +67,13 @@ func NewDir(root string, opts ...OptDir) Store {
 		opt(d)
 	}
 	if d.log == nil {
-		// TODO: is there a better way to create a noop logger?
-		d.log = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(99)}))
+		d.log = slog.Null{}
 	}
 	return d
 }
 
 // WithDirLog includes a logger on the directory store.
-func WithDirLog(log *slog.Logger) OptDir {
+func WithDirLog(log slog.Logger) OptDir {
 	return func(d *dir) {
 		d.log = log
 	}

--- a/olareg.go
+++ b/olareg.go
@@ -2,13 +2,12 @@ package olareg
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
-	"os"
 	"path"
 	"regexp"
 	"strings"
 
+	"github.com/olareg/olareg/internal/slog"
 	"github.com/olareg/olareg/internal/store"
 )
 
@@ -23,7 +22,7 @@ func New(conf Config) http.Handler {
 		log:  conf.Log,
 	}
 	if s.log == nil {
-		s.log = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		s.log = slog.Null{}
 	}
 	switch conf.StoreType {
 	case StoreMem:
@@ -40,7 +39,7 @@ func New(conf Config) http.Handler {
 type server struct {
 	conf  Config
 	store store.Store
-	log   *slog.Logger
+	log   slog.Logger
 	// TODO: add context?
 	// TODO: implement memory store, disk cache, GC handling, etc for the non-disk and non-config data
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

GHA cannot be run on 1.20 and earlier versions of Go.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The `log/slog` calls were moved to using an interface. And injecting `log/slog` is only done in version specific code. This allows support of Go 1.19
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Builds with older versions of Go will work.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Support older versions of Go (1.19 and 1.20).
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
