### PR TITLE
Make blob logging less verbose

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -32,7 +32,9 @@ func (s *server) blobGet(repoStr, arg string) http.HandlerFunc {
 		}
 		rdr, err := repo.BlobGet(d)
 		if err != nil {
-			s.log.Info("failed to open blob", "err", err, "repo", repoStr, "digest", d.String())
+			if r.Method != http.MethodHead {
+				s.log.Debug("failed to open blob", "err", err, "repo", repoStr, "digest", d.String())
+			}
 			if errors.Is(err, types.ErrNotFound) {
 				w.WriteHeader(http.StatusNotFound)
 				_ = types.ErrRespJSON(w, types.ErrInfoBlobUnknown("blob was not found"))


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Blob logging on head requests is very verbose on every query of a missing digest.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Don't log not found errors on a head request. Move other not found errors to the debugging level.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Copy an image with `regctl image copy` and see less verbose logs from the server.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Reduce verbosity in logs for blob head requests.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
