### PR TITLE
Make manifest logging less verbose

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -29,7 +29,9 @@ func (s *server) manifestGet(repoStr, arg string) http.HandlerFunc {
 		// get descriptor for arg from index
 		desc, err := index.GetDesc(arg)
 		if err != nil || desc.Digest.String() == "" {
-			s.log.Info("failed to get descriptor", "err", err, "repo", repoStr, "arg", arg)
+			if r.Method != http.MethodHead {
+				s.log.Debug("failed to get descriptor", "err", err, "repo", repoStr, "arg", arg)
+			}
 			w.WriteHeader(http.StatusNotFound)
 			_ = types.ErrRespJSON(w, types.ErrInfoManifestUnknown("tag or digest was not found in repository"))
 			return


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Manifest logging had the same issue as blob logging.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Reduce the logging level of missing manifests to debug, and only output when not a head request.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Copy a new image to the registry.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Reduce verbosity in logs for manifest head requests.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
