### PR TITLE
Reserve the names of OCI Layout files

### DIFF
--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -36,11 +36,11 @@ func NewMem() Store {
 	}
 }
 
-func (m *mem) RepoGet(repoStr string) Repo {
+func (m *mem) RepoGet(repoStr string) (Repo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if mr, ok := m.repos[repoStr]; ok {
-		return mr
+		return mr, nil
 	}
 	mr := &memRepo{
 		index: types.Index{
@@ -49,7 +49,7 @@ func (m *mem) RepoGet(repoStr string) Repo {
 		blobs: map[digest.Digest][]byte{},
 	}
 	m.repos[repoStr] = mr
-	return mr
+	return mr, nil
 }
 
 // IndexGet returns the current top level index for a repo.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Store interface {
-	RepoGet(repoStr string) Repo
+	RepoGet(repoStr string) (Repo, error)
 }
 
 type Repo interface {

--- a/types/errors.go
+++ b/types/errors.go
@@ -9,6 +9,8 @@ import (
 var (
 	// ErrNotFound is returned when a resource is not found.
 	ErrNotFound = errors.New("not found")
+	// ErrRepoNotAllowed is used when a repository name is not permitted.
+	ErrRepoNotAllowed = errors.New("repository name is not permitted")
 )
 
 // ErrorResp is returned by the registry on an invalid request.


### PR DESCRIPTION
This prevents someone from breaking an OCI Layout with a repo named index.json.

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

A repo name could be used with a value matching an OCI Layout component, breaking either the child or parent repository.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This reserves the names "index.json", "oci-layout", and "blobs" from being used in repository names with the directory storage.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
olareg serve --port 5002 --dir . &
regctl tag ls localhost:5002/index.json
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Reserves the OCI Layout filenames from being used in a repository name.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
