### PR TITLE
Add blob patch methods

### DIFF
--- a/olareg.go
+++ b/olareg.go
@@ -60,30 +60,45 @@ func (s *server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		// handle v2 ping
 		s.v2Ping(resp, req)
 		return
-	} else if matches, ok := matchV2(pathEl, "...", "tags", "list"); ok && (req.Method == http.MethodGet || req.Method == http.MethodHead) {
-		// handle tag listing
-		s.tagList(matches[0]).ServeHTTP(resp, req)
-		return
+	} else if matches, ok := matchV2(pathEl, "...", "manifests", "*"); ok {
+		// handle manifest
+		if req.Method == http.MethodGet || req.Method == http.MethodHead {
+			s.manifestGet(matches[0], matches[1]).ServeHTTP(resp, req)
+			return
+		} else if req.Method == http.MethodPut {
+			s.manifestPut(matches[0], matches[1]).ServeHTTP(resp, req)
+			return
+		} else {
+			resp.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 	} else if matches, ok := matchV2(pathEl, "...", "blobs", "*"); ok && (req.Method == http.MethodGet || req.Method == http.MethodHead) {
 		// handle blob get
 		s.blobGet(matches[0], matches[1]).ServeHTTP(resp, req)
+		return
+	} else if matches, ok := matchV2(pathEl, "...", "tags", "list"); ok && (req.Method == http.MethodGet || req.Method == http.MethodHead) {
+		// handle tag listing
+		s.tagList(matches[0]).ServeHTTP(resp, req)
 		return
 	} else if matches, ok := matchV2(pathEl, "...", "blobs", "uploads"); ok && req.Method == http.MethodPost {
 		// handle blob post
 		s.blobUploadPost(matches[0]).ServeHTTP(resp, req)
 		return
-	} else if matches, ok := matchV2(pathEl, "...", "blobs", "uploads", "*"); ok && req.Method == http.MethodPut {
-		// handle blob put
-		s.blobUploadPut(matches[0], matches[1]).ServeHTTP(resp, req)
-		return
-	} else if matches, ok := matchV2(pathEl, "...", "manifests", "*"); ok && (req.Method == http.MethodGet || req.Method == http.MethodHead) {
-		// handle manifest get
-		s.manifestGet(matches[0], matches[1]).ServeHTTP(resp, req)
-		return
-	} else if matches, ok := matchV2(pathEl, "...", "manifests", "*"); ok && req.Method == http.MethodPut {
-		// handle manifest put
-		s.manifestPut(matches[0], matches[1]).ServeHTTP(resp, req)
-		return
+	} else if matches, ok := matchV2(pathEl, "...", "blobs", "uploads", "*"); ok {
+		// handle blob upload methods
+		if req.Method == http.MethodPatch {
+			s.blobUploadPatch(matches[0], matches[1]).ServeHTTP(resp, req)
+			return
+		} else if req.Method == http.MethodPut {
+			s.blobUploadPut(matches[0], matches[1]).ServeHTTP(resp, req)
+			return
+		} else if req.Method == http.MethodGet {
+			s.blobUploadGet(matches[0], matches[1]).ServeHTTP(resp, req)
+			return
+		} else {
+			resp.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 	} else {
 		resp.WriteHeader(http.StatusNotFound)
 		// TODO: remove response, this is for debugging/development


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the blob patch methods. It also reorganized the http mux a bit to avoid duplicate matchV2 calls.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl registry set --blob-max 50000 localhost:5002
regctl image copy ghcr.io/regclient/regctl localhost:5002/testregctl
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add blob patch methods.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
