### PR TITLE
Add manifest and tag delete

### DIFF
--- a/types/manifest.go
+++ b/types/manifest.go
@@ -94,15 +94,24 @@ func (i Index) GetDesc(arg string) (Descriptor, error) {
 		if err != nil {
 			return dRet, err
 		}
+		// return a matching descriptor, but stripped of any annotations to avoid mixing with tags
 		for _, d := range i.Manifests {
 			if d.Digest == dig {
-				return d, nil
+				return Descriptor{
+					MediaType: d.MediaType,
+					Digest:    d.Digest,
+					Size:      d.Size,
+				}, nil
 			}
 		}
 		if i.childManifests != nil {
 			for _, d := range i.childManifests {
 				if d.Digest == dig {
-					return d, nil
+					return Descriptor{
+						MediaType: d.MediaType,
+						Digest:    d.Digest,
+						Size:      d.Size,
+					}, nil
 				}
 			}
 		}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the manifest delete API. There is no validation to refuse deleting a manifest that is listed in an index.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
regctl tag rm ...
regctl manifest rm ...
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Add manifest delete API
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
