### PR TITLE
Add blob delete API

### DIFF
--- a/cmd/olareg/serve.go
+++ b/cmd/olareg/serve.go
@@ -13,11 +13,13 @@ import (
 )
 
 type serveOpts struct {
-	root      *rootOpts
-	addr      string
-	port      int
-	storeType string
-	storeDir  string
+	root        *rootOpts
+	addr        string
+	port        int
+	storeType   string
+	storeDir    string
+	apiBlobDel  bool
+	apiReferrer bool
 }
 
 func newServeCmd(root *rootOpts) *cobra.Command {
@@ -34,6 +36,8 @@ func newServeCmd(root *rootOpts) *cobra.Command {
 	newCmd.Flags().IntVar(&opts.port, "port", 80, "listener port")
 	newCmd.Flags().StringVar(&opts.storeDir, "dir", ".", "root directory for storage")
 	newCmd.Flags().StringVar(&opts.storeType, "store-type", "dir", "storage type (dir, mem)")
+	newCmd.Flags().BoolVar(&opts.apiBlobDel, "api-blob-delete", false, "enable blob delete API")
+	newCmd.Flags().BoolVar(&opts.apiReferrer, "api-referrer", true, "enable referrer API")
 	return newCmd
 }
 
@@ -47,6 +51,10 @@ func (opts *serveOpts) run(cmd *cobra.Command, args []string) error {
 		StoreType: storeType,
 		RootDir:   opts.storeDir,
 		Log:       opts.root.log,
+		API: config.ConfigAPI{
+			BlobDelete: config.ConfigAPIBlobDelete{Enabled: &opts.apiBlobDel},
+			Referrer:   config.ConfigAPIReferrer{Enabled: &opts.apiReferrer},
+		},
 	}
 	handler := olareg.New(conf)
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", opts.addr, opts.port))

--- a/config/config.go
+++ b/config/config.go
@@ -17,17 +17,30 @@ const (
 )
 
 type Config struct {
-	StoreType        Store
-	RootDir          string
-	Log              slog.Logger
-	ManifestLimit    int64
-	DisableReferrers bool
+	StoreType     Store
+	RootDir       string
+	Log           slog.Logger
+	ManifestLimit int64
+	API           ConfigAPI
 	// TODO: TLS and listener options? not needed here if only providing handler
 	// TODO: GC policy, delete untagged? timeouts for partial blobs?
 	// TODO: proxy settings, pull only, or push+pull cache
 	// TODO: memory option to load from disk
 	// TODO: auth options (basic, bearer)
 	// TODO: allowed actions: get/head, put, delete, catalog
+}
+
+type ConfigAPI struct {
+	BlobDelete ConfigAPIBlobDelete
+	Referrer   ConfigAPIReferrer
+}
+
+type ConfigAPIBlobDelete struct {
+	Enabled *bool
+}
+
+type ConfigAPIReferrer struct {
+	Enabled *bool
 }
 
 func (s Store) MarshalText() ([]byte, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,6 +32,8 @@ type Repo interface {
 	BlobGet(d digest.Digest) (io.ReadSeekCloser, error)
 	// BlobCreate is used to create a new blob.
 	BlobCreate(opts ...BlobOpt) (BlobCreator, error)
+	// BlobDelete deletes an entry from the CAS.
+	BlobDelete(d digest.Digest) error
 }
 
 type BlobOpt func(*blobConfig)
@@ -264,4 +266,11 @@ func repoGetIndex(repo Repo, d types.Descriptor) (types.Index, error) {
 		return i, err
 	}
 	return i, nil
+}
+
+func boolDefault(b *bool, def bool) bool {
+	if b != nil {
+		return *b
+	}
+	return def
 }

--- a/olareg.go
+++ b/olareg.go
@@ -81,6 +81,10 @@ func (s *server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 			// handle blob get
 			s.blobGet(matches[0], matches[1]).ServeHTTP(resp, req)
 			return
+		} else if req.Method == http.MethodDelete && boolDefault(s.conf.API.BlobDelete.Enabled, false) {
+			// handle blob delete
+			s.blobDelete(matches[0], matches[1]).ServeHTTP(resp, req)
+			return
 		} else if matches[1] == "uploads" && req.Method == http.MethodPost {
 			// handle blob post
 			s.blobUploadPost(matches[0]).ServeHTTP(resp, req)
@@ -90,7 +94,7 @@ func (s *server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 			resp.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-	} else if matches, ok := matchV2(pathEl, "...", "referrers", "*"); ok && !s.conf.DisableReferrers {
+	} else if matches, ok := matchV2(pathEl, "...", "referrers", "*"); ok && boolDefault(s.conf.API.Referrer.Enabled, true) {
 		if req.Method == http.MethodGet || req.Method == http.MethodHead {
 			// handle referrer get
 			s.referrerGet(matches[0], matches[1]).ServeHTTP(resp, req)
@@ -176,4 +180,11 @@ func (s *server) v2Ping(resp http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodHead {
 		_, _ = resp.Write([]byte("{}"))
 	}
+}
+
+func boolDefault(b *bool, def bool) bool {
+	if b != nil {
+		return *b
+	}
+	return def
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

By default, this API is not allowed. GC should be added later to handle this automatically.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
olareg serve --port 5002 --store-type mem --api-blob-delete=true
```

Then push and delete a blob from the OCI APIs (e.g. OCI distribution-spec conformance tests).
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Support blob delete API, disabled by default.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
