### PR TITLE
Add top level API limits on push and delete

### DIFF
--- a/cmd/olareg/serve.go
+++ b/cmd/olareg/serve.go
@@ -18,6 +18,8 @@ type serveOpts struct {
 	port        int
 	storeType   string
 	storeDir    string
+	apiPush     bool
+	apiDelete   bool
 	apiBlobDel  bool
 	apiReferrer bool
 }
@@ -36,6 +38,8 @@ func newServeCmd(root *rootOpts) *cobra.Command {
 	newCmd.Flags().IntVar(&opts.port, "port", 80, "listener port")
 	newCmd.Flags().StringVar(&opts.storeDir, "dir", ".", "root directory for storage")
 	newCmd.Flags().StringVar(&opts.storeType, "store-type", "dir", "storage type (dir, mem)")
+	newCmd.Flags().BoolVar(&opts.apiPush, "api-push", true, "enable push APIs")
+	newCmd.Flags().BoolVar(&opts.apiDelete, "api-delete", true, "enable delete APIs")
 	newCmd.Flags().BoolVar(&opts.apiBlobDel, "api-blob-delete", false, "enable blob delete API")
 	newCmd.Flags().BoolVar(&opts.apiReferrer, "api-referrer", true, "enable referrer API")
 	return newCmd
@@ -48,12 +52,16 @@ func (opts *serveOpts) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to parse store type %s: %w", opts.storeType, err)
 	}
 	conf := config.Config{
-		StoreType: storeType,
-		RootDir:   opts.storeDir,
-		Log:       opts.root.log,
+		Storage: config.ConfigStorage{
+			StoreType: storeType,
+			RootDir:   opts.storeDir,
+		},
+		Log: opts.root.log,
 		API: config.ConfigAPI{
-			BlobDelete: config.ConfigAPIBlobDelete{Enabled: &opts.apiBlobDel},
-			Referrer:   config.ConfigAPIReferrer{Enabled: &opts.apiReferrer},
+			PushEnabled:   &opts.apiPush,
+			DeleteEnabled: &opts.apiDelete,
+			Blob:          config.ConfigAPIBlob{DeleteEnabled: &opts.apiBlobDel},
+			Referrer:      config.ConfigAPIReferrer{Enabled: &opts.apiReferrer},
 		},
 	}
 	handler := olareg.New(conf)

--- a/config/config.go
+++ b/config/config.go
@@ -11,17 +11,16 @@ import (
 type Store int
 
 const (
-	StoreMem    Store = iota // StoreMem only uses memory for an ephemeral registry
+	StoreUndef  Store = iota // undefined backend storage is the invalid zero value
+	StoreMem                 // StoreMem only uses memory for an ephemeral registry
 	StoreDir                 // StoreDir tracks each repository with a separate blob store
 	StoreShared              // StoreShared tracks the blobs in a single store for less disk usage
 )
 
 type Config struct {
-	StoreType     Store
-	RootDir       string
-	Log           slog.Logger
-	ManifestLimit int64
-	API           ConfigAPI
+	Storage ConfigStorage
+	API     ConfigAPI
+	Log     slog.Logger
 	// TODO: TLS and listener options? not needed here if only providing handler
 	// TODO: GC policy, delete untagged? timeouts for partial blobs?
 	// TODO: proxy settings, pull only, or push+pull cache
@@ -30,13 +29,25 @@ type Config struct {
 	// TODO: allowed actions: get/head, put, delete, catalog
 }
 
-type ConfigAPI struct {
-	BlobDelete ConfigAPIBlobDelete
-	Referrer   ConfigAPIReferrer
+type ConfigStorage struct {
+	StoreType Store
+	RootDir   string
 }
 
-type ConfigAPIBlobDelete struct {
-	Enabled *bool
+type ConfigAPI struct {
+	PushEnabled   *bool
+	DeleteEnabled *bool
+	Manifest      ConfigAPIManifest
+	Blob          ConfigAPIBlob
+	Referrer      ConfigAPIReferrer
+}
+
+type ConfigAPIManifest struct {
+	Limit int64
+}
+
+type ConfigAPIBlob struct {
+	DeleteEnabled *bool
 }
 
 type ConfigAPIReferrer struct {

--- a/internal/store/dir.go
+++ b/internal/store/dir.go
@@ -66,7 +66,7 @@ func NewDir(conf config.Config, opts ...Opts) Store {
 		opt(&sc)
 	}
 	d := &dir{
-		root:  conf.RootDir,
+		root:  conf.Storage.RootDir,
 		repos: map[string]*dirRepo{},
 		log:   sc.log,
 		conf:  conf,

--- a/manifest.go
+++ b/manifest.go
@@ -209,9 +209,9 @@ func (s *server) manifestPut(repoStr, arg string) http.HandlerFunc {
 			s.log.Debug("unsupported media type", "repo", repoStr, "arg", arg, "mediaType", mt)
 			return
 		}
-		if r.ContentLength > s.conf.ManifestLimit {
+		if r.ContentLength > s.conf.API.Manifest.Limit {
 			w.WriteHeader(http.StatusRequestEntityTooLarge)
-			_ = types.ErrRespJSON(w, types.ErrInfoManifestInvalid(fmt.Sprintf("manifest too large, limited to %d bytes", s.conf.ManifestLimit)))
+			_ = types.ErrRespJSON(w, types.ErrInfoManifestInvalid(fmt.Sprintf("manifest too large, limited to %d bytes", s.conf.API.Manifest.Limit)))
 			return
 		}
 		// parse arg
@@ -228,7 +228,7 @@ func (s *server) manifestPut(repoStr, arg string) http.HandlerFunc {
 			}
 		}
 		// read manifest
-		rLimit := io.LimitReader(r.Body, s.conf.ManifestLimit)
+		rLimit := io.LimitReader(r.Body, s.conf.API.Manifest.Limit)
 		mRaw, err := io.ReadAll(rLimit)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the ability to limit push and delete APIs. There was some configuration refactoring in the process.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
olareg --api-delete=false ...
olareg --api-push=false ...
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: allow push and/or delete APIs to be disabled.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
