### PR TITLE
Update index AddDesc and RmDesc methods for referrers

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -181,7 +181,6 @@ func referrerConvert(repo Repo, index *types.Index) (bool, error) {
 			newD.Annotations = map[string]string{
 				types.AnnotReferrerSubject: subject.String(),
 			}
-			index.RmDesc(d)
 			index.AddDesc(newD)
 			delete(referrerAdd, subject)
 		} else {

--- a/types/manifest.go
+++ b/types/manifest.go
@@ -139,26 +139,35 @@ func (i *Index) GetByAnnotation(key, val string) (Descriptor, error) {
 }
 
 // AddDesc adds an entry to the Index with deduplication.
-// If a descriptor exists but a tag is being added, the tag is added to the existing descriptor.
+// If a descriptor exists but a tag or referrer annotation are being added, an existing descriptor will be updated if found.
 // If the descriptor exists as a child, it is removed from the child entries.
 // This method ignores and may lose other fields and annotations other than the OCI reference annotation.
-// The "WithChildren" option moves matching untagged descriptors to child manifest list.
+// The "WithChildren" option moves matching descriptors without annotations to child manifest list.
 func (i *Index) AddDesc(d Descriptor, opts ...IndexOpt) {
 	conf := indexConf{children: []Descriptor{}}
 	for _, opt := range opts {
 		opt(&conf)
 	}
 	tag := ""
+	referrer := ""
 	if d.Annotations != nil {
 		tag = d.Annotations[AnnotRefName]
+		referrer = d.Annotations[AnnotReferrerSubject]
 	}
-	// search for another descriptor to untag
-	if tag != "" {
-		for mi, md := range i.Manifests {
-			if md.Digest != d.Digest && md.Annotations != nil && md.Annotations[AnnotRefName] == tag {
-				delete(i.Manifests[mi].Annotations, AnnotRefName)
-				break // it's not valid to set the same tag twice
+	// search for another descriptor to untag and referrers to delete
+	if tag != "" || referrer != "" {
+		mi := len(i.Manifests) - 1
+		for mi >= 0 {
+			if i.Manifests[mi].Digest != d.Digest && i.Manifests[mi].Annotations != nil {
+				if i.Manifests[mi].Annotations[AnnotRefName] == tag {
+					delete(i.Manifests[mi].Annotations, AnnotRefName)
+				}
+				if i.Manifests[mi].Annotations[AnnotReferrerSubject] == referrer {
+					i.Manifests = append(i.Manifests[:mi], i.Manifests[mi+1:]...)
+					continue
+				}
 			}
+			mi--
 		}
 	}
 	// remove child entry if found
@@ -169,22 +178,11 @@ func (i *Index) AddDesc(d Descriptor, opts ...IndexOpt) {
 			break
 		}
 	}
-	// search for matching digests
-	for mi, md := range i.Manifests {
-		if md.Digest == d.Digest {
-			if tag == "" {
-				return
-			}
-			if md.Annotations == nil || md.Annotations[AnnotRefName] == "" || md.Annotations[AnnotRefName] == tag {
-				i.Manifests[mi] = d
-				return
-			}
-		}
-	}
-	// move listed children
+	// Move entries from WithChildren option to childManifest list.
+	// These are from child descriptors when an index is later pushed.
 	for _, cd := range conf.children {
 		for mi := range i.Manifests {
-			if i.Manifests[mi].Digest == cd.Digest && (i.Manifests[mi].Annotations == nil || i.Manifests[mi].Annotations[AnnotRefName] == "") {
+			if i.Manifests[mi].Digest == cd.Digest && len(i.Manifests[mi].Annotations) == 0 {
 				i.Manifests[mi] = i.Manifests[len(i.Manifests)-1]
 				i.Manifests = i.Manifests[:len(i.Manifests)-1]
 				i.childManifests = append(i.childManifests, cd)
@@ -192,20 +190,40 @@ func (i *Index) AddDesc(d Descriptor, opts ...IndexOpt) {
 			}
 		}
 	}
-	// append entry
+	// search for matching or compatible entry
+	for mi, md := range i.Manifests {
+		if md.Digest == d.Digest {
+			if tag == "" && referrer == "" {
+				return
+			}
+			if md.Annotations == nil ||
+				((tag == "" || md.Annotations[AnnotRefName] == "" || md.Annotations[AnnotRefName] == tag) &&
+					(referrer == "" || md.Annotations[AnnotReferrerSubject] == "" || md.Annotations[AnnotReferrerSubject] == referrer)) {
+				i.Manifests[mi] = d
+				return
+			}
+		}
+	}
+	// append entry if no match found
 	i.Manifests = append(i.Manifests, d)
 }
 
 // RmDesc deletes a descriptor from the index.
-// If the descriptor has the tag value set, only the tagged entry is deleted.
-// TODO: If the descriptor has the referrers annotation set, the entry with a matching annotation is deleted.
-// Otherwise all references to the digest are removed, including any tag and child references.
+// If the descriptor has a digest and the tag value set, one reference to the untagged digest is preserved.
+// If the digest is blank and either tag or referrer annotations are provided, all matching tags/referrers are deleted.
+// Otherwise all references to the digest are removed.
 func (i *Index) RmDesc(d Descriptor) {
 	tag := ""
-	if d.Annotations != nil && d.Annotations[AnnotRefName] != "" {
-		tag = d.Annotations[AnnotRefName]
+	referrer := ""
+	if d.Annotations != nil {
+		if d.Annotations[AnnotRefName] != "" {
+			tag = d.Annotations[AnnotRefName]
+		}
+		if d.Annotations[AnnotReferrerSubject] != "" {
+			referrer = d.Annotations[AnnotReferrerSubject]
+		}
 	}
-	if tag == "" {
+	if tag == "" && d.Digest != "" {
 		for mi := len(i.childManifests) - 1; mi >= 0; mi-- {
 			if i.childManifests[mi].Digest == d.Digest {
 				i.childManifests[mi] = i.childManifests[len(i.childManifests)-1]
@@ -215,21 +233,26 @@ func (i *Index) RmDesc(d Descriptor) {
 	}
 	found := false
 	for mi := len(i.Manifests) - 1; mi >= 0; mi-- {
-		if i.Manifests[mi].Digest == d.Digest {
-			if tag == "" {
-				i.Manifests[mi] = i.Manifests[len(i.Manifests)-1]
-				i.Manifests = i.Manifests[:len(i.Manifests)-1]
-			} else {
+		if d.Digest != "" && i.Manifests[mi].Digest == d.Digest {
+			if tag != "" {
+				// deleting a tag leaves one untagged manifest entry
 				if found && (i.Manifests[mi].Annotations == nil || i.Manifests[mi].Annotations[AnnotRefName] == tag) {
-					// duplicate entry to delete
 					i.Manifests[mi] = i.Manifests[len(i.Manifests)-1]
 					i.Manifests = i.Manifests[:len(i.Manifests)-1]
 				} else if i.Manifests[mi].Annotations != nil && i.Manifests[mi].Annotations[AnnotRefName] == tag {
-					// remove tag from entry
 					delete(i.Manifests[mi].Annotations, AnnotRefName)
 				}
 				found = true
+			} else {
+				i.Manifests[mi] = i.Manifests[len(i.Manifests)-1]
+				i.Manifests = i.Manifests[:len(i.Manifests)-1]
 			}
+		} else if d.Digest == "" && i.Manifests[mi].Annotations != nil &&
+			((tag != "" && i.Manifests[mi].Annotations[AnnotRefName] == tag) ||
+				(referrer != "" && i.Manifests[mi].Annotations[AnnotReferrerSubject] == referrer)) {
+			// delete all entries pointing to a tag or referrer when digest isn't defined
+			i.Manifests[mi] = i.Manifests[len(i.Manifests)-1]
+			i.Manifests = i.Manifests[:len(i.Manifests)-1]
 		}
 	}
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Referrer conversion was broken.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This updates the index add/rm descriptor methods to be aware of the referrer annotation and manage it appropriately.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Run an action on a repo that has not be converted (still using digest tags). The resulting index.json should be updated with the new annotation.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix referrer conversion.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
