### PR TITLE
Adding Server.Run and Shutdown calls

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -24,7 +24,7 @@ import (
 	"github.com/olareg/olareg/types"
 )
 
-func (s *server) blobGet(repoStr, arg string) http.HandlerFunc {
+func (s *Server) blobGet(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {
@@ -64,7 +64,7 @@ func (s *server) blobGet(repoStr, arg string) http.HandlerFunc {
 	}
 }
 
-func (s *server) blobDelete(repoStr, arg string) http.HandlerFunc {
+func (s *Server) blobDelete(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {
@@ -109,7 +109,7 @@ type blobUploadState struct {
 	Offset int64 `json:"offset"`
 }
 
-func (s *server) blobUploadGet(repoStr, sessionID string) http.HandlerFunc {
+func (s *Server) blobUploadGet(repoStr, sessionID string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		blobUploadMu.Lock()
 		bc, ok := blobUploadSessions[repoStr+":"+sessionID]
@@ -141,7 +141,7 @@ func (s *server) blobUploadGet(repoStr, sessionID string) http.HandlerFunc {
 	}
 }
 
-func (s *server) blobUploadPost(repoStr string) http.HandlerFunc {
+func (s *Server) blobUploadPost(repoStr string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// start a new upload session with the backend storage and track as current upload
 		repo, err := s.store.RepoGet(repoStr)
@@ -243,7 +243,7 @@ func (s *server) blobUploadPost(repoStr string) http.HandlerFunc {
 	}
 }
 
-func (s *server) blobUploadPatch(repoStr, sessionID string) http.HandlerFunc {
+func (s *Server) blobUploadPatch(repoStr, sessionID string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		blobUploadMu.Lock()
 		bc, ok := blobUploadSessions[repoStr+":"+sessionID]
@@ -314,7 +314,7 @@ func (s *server) blobUploadPatch(repoStr, sessionID string) http.HandlerFunc {
 	}
 }
 
-func (s *server) blobUploadPut(repoStr, sessionID string) http.HandlerFunc {
+func (s *Server) blobUploadPut(repoStr, sessionID string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		blobUploadMu.Lock()
 		bc, ok := blobUploadSessions[repoStr+":"+sessionID]

--- a/config/config.go
+++ b/config/config.go
@@ -18,15 +18,20 @@ const (
 )
 
 type Config struct {
+	HTTP    ConfigHTTP
 	Storage ConfigStorage
 	API     ConfigAPI
 	Log     slog.Logger
-	// TODO: TLS and listener options? not needed here if only providing handler
 	// TODO: GC policy, delete untagged? timeouts for partial blobs?
 	// TODO: proxy settings, pull only, or push+pull cache
 	// TODO: memory option to load from disk
 	// TODO: auth options (basic, bearer)
-	// TODO: allowed actions: get/head, put, delete, catalog
+}
+
+type ConfigHTTP struct {
+	Addr     string // address and port to listen on, e.g. ":5000"
+	CertFile string // public certificate for https server (leave blank for http)
+	KeyFile  string // private key for https server (leave blank for http)
 }
 
 type ConfigStorage struct {

--- a/manifest.go
+++ b/manifest.go
@@ -21,7 +21,7 @@ import (
 	"github.com/olareg/olareg/types"
 )
 
-func (s *server) manifestDelete(repoStr, arg string) http.HandlerFunc {
+func (s *Server) manifestDelete(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {
@@ -89,7 +89,7 @@ func (s *server) manifestDelete(repoStr, arg string) http.HandlerFunc {
 	}
 }
 
-func (s *server) manifestGet(repoStr, arg string) http.HandlerFunc {
+func (s *Server) manifestGet(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {
@@ -176,7 +176,7 @@ func (s *server) manifestGet(repoStr, arg string) http.HandlerFunc {
 	}
 }
 
-func (s *server) manifestPut(repoStr, arg string) http.HandlerFunc {
+func (s *Server) manifestPut(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tag := ""
 		var dExpect digest.Digest
@@ -378,7 +378,7 @@ func (s *server) manifestPut(repoStr, arg string) http.HandlerFunc {
 	}
 }
 
-func (s *server) manifestVerifyImage(repo store.Repo, m types.Manifest) []types.ErrorInfo {
+func (s *Server) manifestVerifyImage(repo store.Repo, m types.Manifest) []types.ErrorInfo {
 	// TODO: allow validation to be disabled
 	es := []types.ErrorInfo{}
 	r, err := repo.BlobGet(m.Config.Digest)
@@ -401,7 +401,7 @@ func (s *server) manifestVerifyImage(repo store.Repo, m types.Manifest) []types.
 	return nil
 }
 
-func (s *server) manifestVerifyIndex(repo store.Repo, m types.Index) []types.ErrorInfo {
+func (s *Server) manifestVerifyIndex(repo store.Repo, m types.Index) []types.ErrorInfo {
 	// TODO: allow validation to be disabled
 	es := []types.ErrorInfo{}
 	for _, d := range m.Manifests {

--- a/referrer.go
+++ b/referrer.go
@@ -14,7 +14,7 @@ import (
 
 // referrerGet searches for the referrers response in the index.
 // All errors should return an empty response, no 404's should be generated.
-func (s *server) referrerGet(repoStr, arg string) http.HandlerFunc {
+func (s *Server) referrerGet(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// all errors should return an empty index
 		i := types.Index{
@@ -62,7 +62,7 @@ func (s *server) referrerGet(repoStr, arg string) http.HandlerFunc {
 }
 
 // referrerAdd adds a new referrer entry to a given subject.
-func (s *server) referrerAdd(repo store.Repo, subject digest.Digest, desc types.Descriptor) error {
+func (s *Server) referrerAdd(repo store.Repo, subject digest.Digest, desc types.Descriptor) error {
 	index, err := repo.IndexGet()
 	if err != nil {
 		return err
@@ -132,7 +132,7 @@ func (s *server) referrerAdd(repo store.Repo, subject digest.Digest, desc types.
 }
 
 // referrerDelete removes a referrer entry from a subject.
-func (s *server) referrerDelete(repo store.Repo, subject digest.Digest, desc types.Descriptor) error {
+func (s *Server) referrerDelete(repo store.Repo, subject digest.Digest, desc types.Descriptor) error {
 	// get the index.json
 	index, err := repo.IndexGet()
 	if err != nil {

--- a/tag.go
+++ b/tag.go
@@ -12,7 +12,7 @@ import (
 	"github.com/olareg/olareg/types"
 )
 
-func (s *server) tagList(repoStr string) http.HandlerFunc {
+func (s *Server) tagList(repoStr string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This moves the start of the http server into `olareg`, along with a graceful shutdown command. The `Server` struct was made public, but all variables and most methods on it are still private.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

New APIs are available
<!-- Include steps that can be taken to verify the change -->

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
