### PR TITLE
Fix Index.AddDesc end of slice panic

### DIFF
--- a/types/manifest.go
+++ b/types/manifest.go
@@ -156,18 +156,15 @@ func (i *Index) AddDesc(d Descriptor, opts ...IndexOpt) {
 	}
 	// search for another descriptor to untag and referrers to delete
 	if tag != "" || referrer != "" {
-		mi := len(i.Manifests) - 1
-		for mi >= 0 {
+		for mi := len(i.Manifests) - 1; mi >= 0; mi-- {
 			if i.Manifests[mi].Digest != d.Digest && i.Manifests[mi].Annotations != nil {
 				if i.Manifests[mi].Annotations[AnnotRefName] == tag {
 					delete(i.Manifests[mi].Annotations, AnnotRefName)
 				}
 				if i.Manifests[mi].Annotations[AnnotReferrerSubject] == referrer {
 					i.Manifests = append(i.Manifests[:mi], i.Manifests[mi+1:]...)
-					continue
 				}
 			}
-			mi--
 		}
 	}
 	// remove child entry if found


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The previous logic would continue on the end of the slice after deleting that entry, causing a panic for accessing beyond the end of the slice.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: panic on Index.AddDesc accessing entry beyond end of slice.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
