### PR TITLE
Fix a race in mem.BlobCreate

### DIFF
--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -133,7 +133,10 @@ func (mr *memRepo) BlobCreate(opts ...BlobOpt) (BlobCreator, error) {
 	}
 	// if blob exists, return the appropriate error
 	if conf.expect != "" {
-		if _, ok := mr.blobs[conf.expect]; ok {
+		mr.mu.Lock()
+		_, ok := mr.blobs[conf.expect]
+		mr.mu.Unlock()
+		if ok {
 			return nil, types.ErrBlobExists
 		}
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The check for an existing blob was missing a lock leading to a race.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This fixes the race.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Add lock for data race in mem.BlobCreate.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
