### PR TITLE
Fix a data race on the IndexGet calls

### DIFF
--- a/internal/store/dir.go
+++ b/internal/store/dir.go
@@ -107,7 +107,9 @@ func (d *dir) RepoGet(repoStr string) (Repo, error) {
 
 // IndexGet returns the current top level index for a repo.
 func (dr *dirRepo) IndexGet() (types.Index, error) {
-	err := dr.repoLoad(false, false)
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
+	err := dr.repoLoad(false, true)
 	return dr.index, err
 }
 

--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -72,6 +72,8 @@ func (m *mem) RepoGet(repoStr string) (Repo, error) {
 
 // IndexGet returns the current top level index for a repo.
 func (mr *memRepo) IndexGet() (types.Index, error) {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
 	return mr.index, nil
 }
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

There's a data race on the `IndexGet` calls.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add a lock on `IndexGet`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix a data race on `IndexGet`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
