### PR TITLE
Add Copy methods for Index and child types

### DIFF
--- a/internal/store/dir.go
+++ b/internal/store/dir.go
@@ -110,7 +110,8 @@ func (dr *dirRepo) IndexGet() (types.Index, error) {
 	dr.mu.Lock()
 	defer dr.mu.Unlock()
 	err := dr.repoLoad(false, true)
-	return dr.index, err
+	ic := dr.index.Copy()
+	return ic, err
 }
 
 // IndexAdd adds a new entry to the index and writes the change to index.json.

--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -74,7 +74,8 @@ func (m *mem) RepoGet(repoStr string) (Repo, error) {
 func (mr *memRepo) IndexGet() (types.Index, error) {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
-	return mr.index, nil
+	ic := mr.index.Copy()
+	return ic, nil
 }
 
 // IndexAnnotate sets an annotation on the index.

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -37,3 +37,21 @@ type Descriptor struct {
 	// ArtifactType is the media type of the artifact this descriptor refers to.
 	ArtifactType string `json:"artifactType,omitempty"`
 }
+
+// Copy returns a copy of the descriptor
+func (d Descriptor) Copy() Descriptor {
+	d2 := d
+	if d.URLs != nil {
+		d2.URLs = make([]string, len(d.URLs))
+		copy(d2.URLs, d.URLs)
+	}
+	if d.Data != nil {
+		d2.Data = make([]byte, len(d.Data))
+		copy(d2.Data, d.Data)
+	}
+	if d.Platform != nil {
+		p := d.Platform.Copy()
+		d2.Platform = &p
+	}
+	return d2
+}

--- a/types/manifest.go
+++ b/types/manifest.go
@@ -77,6 +77,30 @@ func (i *Index) AddChildren(children []Descriptor) {
 	i.childManifests = append(i.childManifests, children...)
 }
 
+// Copy returns a deep copy of the index to avoid data races
+func (i Index) Copy() Index {
+	i2 := i
+	i2.Manifests = make([]Descriptor, len(i.Manifests))
+	for im := range i.Manifests {
+		i2.Manifests[im] = i.Manifests[im].Copy()
+	}
+	i2.childManifests = make([]Descriptor, len(i.childManifests))
+	for im := range i.childManifests {
+		i2.childManifests[im] = i.childManifests[im].Copy()
+	}
+	if i.Subject != nil {
+		d := i.Subject.Copy()
+		i2.Subject = &d
+	}
+	if i.Annotations != nil {
+		i2.Annotations = make(map[string]string)
+		for k, v := range i.Annotations {
+			i2.Annotations[k] = v
+		}
+	}
+	return i2
+}
+
 // GetDesc returns a descriptor for a tag or digest, including child descriptors.
 func (i Index) GetDesc(arg string) (Descriptor, error) {
 	var dRet Descriptor

--- a/types/platform.go
+++ b/types/platform.go
@@ -20,3 +20,17 @@ type Platform struct {
 	// Features is an optional field specifying an array of strings, each listing a required CPU feature (for example `sse4` or `aes`).
 	Features []string `json:"features,omitempty"`
 }
+
+// Copy returns a memory safe copy of the Platform object
+func (p Platform) Copy() Platform {
+	p2 := p
+	if p.OSFeatures != nil {
+		p2.OSFeatures = make([]string, len(p.OSFeatures))
+		copy(p2.OSFeatures, p.OSFeatures)
+	}
+	if p.Features != nil {
+		p2.Features = make([]string, len(p.Features))
+		copy(p2.Features, p.Features)
+	}
+	return p2
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

There are still some minor races in the contents of the index being returned from `IndexGet`.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Add `Copy` methods for `Index` and child types. This is used on `IndexGet` to ensure that none of the embedded slices return data by reference.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add `Copy` methods to `Index` and child types.
- Fix: Return a `Index.Copy` in `IndexGet` to prevent data races in nested structures.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
