### PR TITLE
Support read-only storage

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -66,6 +66,11 @@ func (s *Server) blobGet(repoStr, arg string) http.HandlerFunc {
 
 func (s *Server) blobDelete(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if *s.conf.Storage.ReadOnly {
+			w.WriteHeader(http.StatusForbidden)
+			_ = types.ErrRespJSON(w, types.ErrInfoDenied("repository is read-only"))
+			return
+		}
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {
 			if errors.Is(err, types.ErrRepoNotAllowed) {
@@ -143,6 +148,11 @@ func (s *Server) blobUploadGet(repoStr, sessionID string) http.HandlerFunc {
 
 func (s *Server) blobUploadPost(repoStr string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if *s.conf.Storage.ReadOnly {
+			w.WriteHeader(http.StatusForbidden)
+			_ = types.ErrRespJSON(w, types.ErrInfoDenied("repository is read-only"))
+			return
+		}
 		// start a new upload session with the backend storage and track as current upload
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {

--- a/cmd/olareg/serve.go
+++ b/cmd/olareg/serve.go
@@ -21,6 +21,7 @@ type serveOpts struct {
 	tlsKey      string
 	storeType   string
 	storeDir    string
+	storeRO     bool
 	apiPush     bool
 	apiDelete   bool
 	apiBlobDel  bool
@@ -43,6 +44,7 @@ func newServeCmd(root *rootOpts) *cobra.Command {
 	newCmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "TLS key for HTTPS")
 	newCmd.Flags().StringVar(&opts.storeDir, "dir", ".", "root directory for storage")
 	newCmd.Flags().StringVar(&opts.storeType, "store-type", "dir", "storage type (dir, mem)")
+	newCmd.Flags().BoolVar(&opts.storeRO, "store-ro", false, "restrict storage as read-only")
 	newCmd.Flags().BoolVar(&opts.apiPush, "api-push", true, "enable push APIs")
 	newCmd.Flags().BoolVar(&opts.apiDelete, "api-delete", true, "enable delete APIs")
 	newCmd.Flags().BoolVar(&opts.apiBlobDel, "api-blob-delete", false, "enable blob delete API")
@@ -65,6 +67,7 @@ func (opts *serveOpts) run(cmd *cobra.Command, args []string) error {
 		Storage: config.ConfigStorage{
 			StoreType: storeType,
 			RootDir:   opts.storeDir,
+			ReadOnly:  &opts.storeRO,
 		},
 		Log: opts.root.log,
 		API: config.ConfigAPI{

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type ConfigHTTP struct {
 type ConfigStorage struct {
 	StoreType Store
 	RootDir   string
+	ReadOnly  *bool
 }
 
 type ConfigAPI struct {
@@ -77,6 +78,9 @@ func (c *Config) SetDefaults() {
 	}
 	if c.API.Referrer.Enabled == nil {
 		c.API.Referrer.Enabled = &t
+	}
+	if c.Storage.ReadOnly == nil {
+		c.Storage.ReadOnly = &f
 	}
 	if c.API.Manifest.Limit <= 0 {
 		c.API.Manifest.Limit = manifestLimitDefault

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,7 @@ func TestSetDefaults(t *testing.T) {
 	c := Config{Storage: ConfigStorage{StoreType: StoreDir}}
 	c.SetDefaults()
 	if c.API.DeleteEnabled == nil || c.API.PushEnabled == nil || c.API.Blob.DeleteEnabled == nil ||
-		c.API.Referrer.Enabled == nil {
+		c.API.Referrer.Enabled == nil || c.Storage.ReadOnly == nil {
 		t.Errorf("bool default values should not be nil")
 	}
 	if c.API.Manifest.Limit == 0 {

--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -131,6 +131,9 @@ func (mr *memRepo) IndexGet() (types.Index, error) {
 
 // IndexInsert adds a new entry to the index and writes the change to index.json.
 func (mr *memRepo) IndexInsert(desc types.Descriptor, opts ...types.IndexOpt) error {
+	if *mr.conf.Storage.ReadOnly {
+		return types.ErrReadOnly
+	}
 	mr.mu.Lock()
 	mr.index.AddDesc(desc, opts...)
 	mr.mu.Unlock()
@@ -139,6 +142,9 @@ func (mr *memRepo) IndexInsert(desc types.Descriptor, opts ...types.IndexOpt) er
 
 // IndexRemove removes an entry from the index and writes the change to index.json.
 func (mr *memRepo) IndexRemove(desc types.Descriptor) error {
+	if *mr.conf.Storage.ReadOnly {
+		return types.ErrReadOnly
+	}
 	mr.mu.Lock()
 	mr.index.RmDesc(desc)
 	mr.mu.Unlock()
@@ -180,6 +186,9 @@ func (mr *memRepo) blobGet(d digest.Digest, locked bool) (io.ReadSeekCloser, err
 
 // BlobCreate is used to create a new blob.
 func (mr *memRepo) BlobCreate(opts ...BlobOpt) (BlobCreator, error) {
+	if *mr.conf.Storage.ReadOnly {
+		return nil, types.ErrReadOnly
+	}
 	conf := blobConfig{
 		algo: digest.Canonical,
 	}
@@ -212,6 +221,9 @@ func (mr *memRepo) BlobCreate(opts ...BlobOpt) (BlobCreator, error) {
 
 // BlobDelete deletes an entry from the CAS.
 func (mr *memRepo) BlobDelete(d digest.Digest) error {
+	if *mr.conf.Storage.ReadOnly {
+		return types.ErrReadOnly
+	}
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 	_, ok := mr.blobs[d]

--- a/manifest.go
+++ b/manifest.go
@@ -23,6 +23,11 @@ import (
 
 func (s *Server) manifestDelete(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if *s.conf.Storage.ReadOnly {
+			w.WriteHeader(http.StatusForbidden)
+			_ = types.ErrRespJSON(w, types.ErrInfoDenied("repository is read-only"))
+			return
+		}
 		repo, err := s.store.RepoGet(repoStr)
 		if err != nil {
 			if errors.Is(err, types.ErrRepoNotAllowed) {
@@ -178,6 +183,11 @@ func (s *Server) manifestGet(repoStr, arg string) http.HandlerFunc {
 
 func (s *Server) manifestPut(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if *s.conf.Storage.ReadOnly {
+			w.WriteHeader(http.StatusForbidden)
+			_ = types.ErrRespJSON(w, types.ErrInfoDenied("repository is read-only"))
+			return
+		}
 		tag := ""
 		var dExpect digest.Digest
 		addOpts := []types.IndexOpt{}

--- a/types/errors.go
+++ b/types/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrBlobExists = errors.New("blob exists")
 	// ErrNotFound is returned when a resource is not found.
 	ErrNotFound = errors.New("not found")
+	// ErrReadOnly is returned when the storage system does not permit write access.
+	ErrReadOnly = errors.New("read only storage")
 	// ErrRepoNotAllowed is used when a repository name is not permitted.
 	ErrRepoNotAllowed = errors.New("repository name is not permitted")
 )


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This allows the server to run without modifying the underlying storage. This avoids the automatic conversion of referrers from modifying the index.json file, along with disabling manifest and blob put.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
olareg serve --store-type dir --store-ro
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Support read-only store.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
