### PR TITLE
Fix a race condition in the store test

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -18,7 +18,6 @@ import (
 
 func TestStore(t *testing.T) {
 	t.Parallel()
-	start := time.Now()
 	existingRepo := "testrepo"
 	existingTag := "v1"
 	newRepo := "new-repo"
@@ -225,6 +224,8 @@ func TestStore(t *testing.T) {
 			})
 			t.Run("New", func(t *testing.T) {
 				t.Parallel()
+				// subtract a second to deal with race conditions in the time granularity from directory storage
+				start := time.Now().Add(time.Second * -1)
 				// get new repo
 				repo, err := s.RepoGet(newRepo)
 				if err != nil {
@@ -311,7 +312,7 @@ func TestStore(t *testing.T) {
 					t.Errorf("failed to get metadata on new blob: %v", err)
 				}
 				if m.mod.Before(start) {
-					t.Errorf("new blob mod time is before test start")
+					t.Errorf("new blob mod time is before test start (%s < %s)", m.mod.String(), start.String())
 				}
 				rdr, err = repo.BlobGet(newManifestDigest)
 				if err != nil {
@@ -333,7 +334,7 @@ func TestStore(t *testing.T) {
 					t.Errorf("failed to get metadata on new manifest: %v", err)
 				}
 				if m.mod.Before(start) {
-					t.Errorf("new manifest mod time is before test start")
+					t.Errorf("new manifest mod time is before test start (%s < %s)", m.mod.String(), start.String())
 				}
 				// add index entry
 				newDesc := types.Descriptor{


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The directory timestamps have a different granularity from time.Now resulting in a false negative.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This sets the start time inside the parallel running test, and subtracts a second since some tests of the directory store report back a slightly earlier time.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Running just the internal/store tests a few times would previously trigger this failure every few runs:

```shell
go test ./internal/store
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix a race in the store test.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
