### PR TITLE
Cancel active uploads on store close

### DIFF
--- a/internal/store/dir.go
+++ b/internal/store/dir.go
@@ -137,6 +137,10 @@ func (d *dir) Close() error {
 		d.mu.Unlock()
 		repo.wg.Wait()
 		if !*d.conf.Storage.ReadOnly {
+			// cancel all uploads
+			for _, bc := range repo.uploads {
+				bc.Cancel()
+			}
 			_ = repo.gc()
 		}
 		d.mu.Lock()

--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -131,6 +131,10 @@ func (m *mem) Close() error {
 		}
 		m.mu.Unlock()
 		repo.wg.Wait()
+		// cancel all uploads
+		for _, bc := range repo.uploads {
+			bc.Cancel()
+		}
 		m.mu.Lock()
 		delete(m.repos, r)
 	}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

When closing a store, cancel any leftover uploads.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Cancel the server while a push is running, verify the `_upload` directory in the repo is empty.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Cancel remaining uploads when store is closed.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
