### PR TITLE
Version bump

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,11 +127,11 @@ jobs:
       uses: anchore/sbom-action/download-syft@b6a39da80722a2cb0ef5d197531764a89b5d48c3 # v0.15.8
       id: syft
       with:
-        syft-version: "v0.103.1"
+        syft-version: "v0.104.0"
     
     # Use regctl to modify olareg images to improve reproducibility
     - name: Install regctl
-      uses: regclient/actions/regctl-installer@36cf95c1ea691643b8e8aad3d10b8b8658fad984 # main
+      uses: regclient/actions/regctl-installer@d8097ee5dd5cdf150516315919b58509fc7f4cfa # main
       if: github.event_name != 'pull_request' && github.repository_owner == 'olareg'
 
     - name: Mutate

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gover: ["1.19", "1.20", "1.21"]
+        gover: ["1.20", "1.21", "1.22"]
 
     env:
-      RELEASE_GO_VER: "1.21"
+      RELEASE_GO_VER: "1.22"
       # do not automatically upgrade go to a different version: https://go.dev/doc/toolchain
       GOTOOLCHAIN: "local"
 
@@ -63,7 +63,7 @@ jobs:
       uses: anchore/sbom-action/download-syft@b6a39da80722a2cb0ef5d197531764a89b5d48c3 # v0.15.8
       id: syft
       with:
-        syft-version: "v0.103.1"
+        syft-version: "v0.104.0"
 
     - name: Build artifacts
       if: startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main'
@@ -133,7 +133,7 @@ jobs:
 
     - name: Save artifacts
       if: github.ref == 'refs/heads/main' && matrix.gover == env.RELEASE_GO_VER
-      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: binaries
         path: ./artifacts/

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,6 @@ jobs:
 
       # required for Code scanning alerts
       - name: "Upload SARIF results to code scanning"
-        uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
+        uses: github/codeql-action/upload-sarif@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/vulnscans.yml
+++ b/.github/workflows/vulnscans.yml
@@ -13,7 +13,7 @@ jobs:
     name: Go Vuln Check
     runs-on: ubuntu-latest
     env:
-      RELEASE_GO_VER: "1.21"
+      RELEASE_GO_VER: "1.22"
 
     steps:
     - name: Check out code

--- a/.version-bump.lock
+++ b/.version-bump.lock
@@ -1,12 +1,12 @@
 {"name":"gha-uses-semver","key":"actions/checkout","version":"v4.1.1"}
 {"name":"gha-uses-semver","key":"actions/setup-go","version":"v5.0.0"}
 {"name":"gha-uses-semver","key":"actions/stale","version":"v9.0.0"}
-{"name":"gha-uses-semver","key":"actions/upload-artifact","version":"v4.3.0"}
+{"name":"gha-uses-semver","key":"actions/upload-artifact","version":"v4.3.1"}
 {"name":"gha-uses-semver","key":"anchore/sbom-action","version":"v0.15.8"}
 {"name":"gha-uses-semver","key":"docker/build-push-action","version":"v5.1.0"}
 {"name":"gha-uses-semver","key":"docker/login-action","version":"v3.0.0"}
 {"name":"gha-uses-semver","key":"docker/setup-buildx-action","version":"v3.0.0"}
-{"name":"gha-uses-semver","key":"github/codeql-action","version":"v3.23.2"}
+{"name":"gha-uses-semver","key":"github/codeql-action","version":"v3.24.0"}
 {"name":"gha-uses-semver","key":"ossf/scorecard-action","version":"v2.3.1"}
 {"name":"gha-uses-semver","key":"sigstore/cosign-installer","version":"v3.4.0"}
 {"name":"gha-uses-semver","key":"softprops/action-gh-release","version":"v0.1.15"}
@@ -15,7 +15,7 @@
 {"name":"git-tag-semver","key":"github.com/icholy/gomajor","version":"v0.10.1"}
 {"name":"git-tag-semver","key":"github.com/securego/gosec","version":"v2.18.2"}
 {"name":"git-tag-semver","key":"github.com/sigstore/cosign","version":"v2.2.3"}
-{"name":"git-tag-semver","key":"go.googlesource.com/vuln","version":"v1.0.3"}
+{"name":"git-tag-semver","key":"go.googlesource.com/vuln","version":"v1.0.4"}
 {"name":"github-commit-match","key":"actions/checkout:v4.1.1","version":"b4ffde65f46336ab88eb53be808477a3936bae11"}
 {"name":"github-commit-match","key":"actions/setup-go:v5.0.0","version":"0c52d547c9bc32b1aa3301fd7a9cb496313a4491"}
 {"name":"github-commit-match","key":"actions/stale:v8.0.0","version":"1160a2240286f5da8ec72b1c0816ce2481aabf84"}
@@ -24,6 +24,7 @@
 {"name":"github-commit-match","key":"actions/upload-artifact:v4.0.0","version":"c7d193f32edcb7bfad88892161225aeda64e9392"}
 {"name":"github-commit-match","key":"actions/upload-artifact:v4.1.0","version":"1eb3cb2b3e0f29609092a73eb033bb759a334595"}
 {"name":"github-commit-match","key":"actions/upload-artifact:v4.3.0","version":"26f96dfa697d77e81fd5907df203aa23a56210a8"}
+{"name":"github-commit-match","key":"actions/upload-artifact:v4.3.1","version":"5d5d22a31266ced268874388b861e4b58bb5c2f3"}
 {"name":"github-commit-match","key":"anchore/sbom-action:v0.15.1","version":"5ecf649a417b8ae17dc8383dc32d46c03f2312df"}
 {"name":"github-commit-match","key":"anchore/sbom-action:v0.15.3","version":"c7f031d9249a826a082ea14c79d3b686a51d485a"}
 {"name":"github-commit-match","key":"anchore/sbom-action:v0.15.5","version":"24b0d5238516480139aa8bc6f92eeb7b54a9eb0a"}
@@ -38,8 +39,9 @@
 {"name":"github-commit-match","key":"github/codeql-action:v3.23.0","version":"e5f05b81d5b6ff8cfa111c80c22c5fd02a384118"}
 {"name":"github-commit-match","key":"github/codeql-action:v3.23.1","version":"0b21cf2492b6b02c465a3e5d7c473717ad7721ba"}
 {"name":"github-commit-match","key":"github/codeql-action:v3.23.2","version":"b7bf0a3ed3ecfa44160715d7c442788f65f0f923"}
+{"name":"github-commit-match","key":"github/codeql-action:v3.24.0","version":"e8893c57a1f3a2b659b6b55564fdfdbbd2982911"}
 {"name":"github-commit-match","key":"ossf/scorecard-action:v2.3.1","version":"0864cf19026789058feabb7e87baa5f140aac736"}
-{"name":"github-commit-match","key":"regclient/actions:main","version":"36cf95c1ea691643b8e8aad3d10b8b8658fad984"}
+{"name":"github-commit-match","key":"regclient/actions:main","version":"d8097ee5dd5cdf150516315919b58509fc7f4cfa"}
 {"name":"github-commit-match","key":"sigstore/cosign-installer:v3.2.0","version":"1fc5bd396d372bee37d608f955b336615edf79c8"}
 {"name":"github-commit-match","key":"sigstore/cosign-installer:v3.3.0","version":"9614fae9e5c5eddabb09f90a270fcb487c9f7149"}
 {"name":"github-commit-match","key":"sigstore/cosign-installer:v3.4.0","version":"e1523de7571e31dbe865fd2e80c5c7c23ae71eb4"}
@@ -49,16 +51,18 @@
 {"name":"registry-digest-arg","key":"docker.io/library/alpine:3.19.1","version":"sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b"}
 {"name":"registry-digest-arg","key":"docker.io/library/golang:1.21.5-alpine","version":"sha256:4db4aac30880b978cae5445dd4a706215249ad4f43d28bd7cdf7906e9be8dd6b"}
 {"name":"registry-digest-arg","key":"docker.io/library/golang:1.21.6-alpine","version":"sha256:a6a7f1fcf12f5efa9e04b1e75020931a616cd707f14f62ab5262bfbe109aa84a"}
+{"name":"registry-digest-arg","key":"docker.io/library/golang:1.22.0-alpine","version":"sha256:8e96e6cff6a388c2f70f5f662b64120941fcd7d4b89d62fec87520323a316bd9"}
 {"name":"registry-digest-match","key":"anchore/syft:v0.100.0","version":"sha256:df7b07bfadff45e0135d74f22478f47b16ac6aff4e8dbd93133fcae3bbbb790d"}
 {"name":"registry-digest-match","key":"anchore/syft:v0.101.1","version":"sha256:ea3df0f0d7b85b352911f2b4a06fd08e2f19cdc793812c8766f7813b6a1e98cb"}
 {"name":"registry-digest-match","key":"anchore/syft:v0.103.1","version":"sha256:96c56b2554079d90e5fc8999278638ecca6454713fceebd26321d0698975b243"}
+{"name":"registry-digest-match","key":"anchore/syft:v0.104.0","version":"sha256:aeb052d18121587de9138ca715fc3207ef86358a56bd49ebd2d3ba27169c09d1"}
 {"name":"registry-digest-match","key":"anchore/syft:v0.98.0","version":"sha256:b353bf516310fcbc86676bb20849929298034e80f15873e63da18acdf7080b4e"}
 {"name":"registry-digest-match","key":"anchore/syft:v0.99.0","version":"sha256:07d598b6a95280ed6ecc128685192173a00f370b5326cf50c62500d559075e1d"}
-{"name":"registry-golang-latest","key":"golang-latest","version":"1.21"}
-{"name":"registry-golang-matrix","key":"golang-matrix","version":"[\"1.19\", \"1.20\", \"1.21\"]"}
-{"name":"registry-golang-oldest","key":"golang-oldest","version":"1.19"}
-{"name":"registry-tag-arg-semver","key":"anchore/syft","version":"v0.103.1"}
+{"name":"registry-golang-latest","key":"golang-latest","version":"1.22"}
+{"name":"registry-golang-matrix","key":"golang-matrix","version":"[\"1.20\", \"1.21\", \"1.22\"]"}
+{"name":"registry-golang-oldest","key":"golang-oldest","version":"1.20"}
+{"name":"registry-tag-arg-semver","key":"anchore/syft","version":"v0.104.0"}
 {"name":"registry-tag-arg-semver","key":"davidanson/markdownlint-cli2","version":"v0.12.1"}
 {"name":"registry-tag-arg-semver","key":"docker.io/library/alpine","version":"3.19.1"}
-{"name":"registry-tag-arg-semver","key":"docker.io/library/golang","version":"1.21.6"}
-{"name":"registry-tag-match-semver","key":"anchore/syft","version":"v0.103.1"}
+{"name":"registry-tag-arg-semver","key":"docker.io/library/golang","version":"1.22.0"}
+{"name":"registry-tag-match-semver","key":"anchore/syft","version":"v0.104.0"}

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ endif
 MARKDOWN_LINT_VER?=v0.12.1
 GOMAJOR_VER?=v0.10.1
 GOSEC_VER?=v2.18.2
-GO_VULNCHECK_VER?=v1.0.3
+GO_VULNCHECK_VER?=v1.0.4
 OSV_SCANNER_VER?=v1.6.2
 SYFT?=$(shell command -v syft 2>/dev/null)
 SYFT_CMD_VER:=$(shell [ -x "$(SYFT)" ] && echo "v$$($(SYFT) version | awk '/^Version: / {print $$2}')" || echo "0")
-SYFT_VERSION?=v0.103.1
-SYFT_CONTAINER?=anchore/syft:v0.103.1@sha256:96c56b2554079d90e5fc8999278638ecca6454713fceebd26321d0698975b243
+SYFT_VERSION?=v0.104.0
+SYFT_CONTAINER?=anchore/syft:v0.104.0@sha256:aeb052d18121587de9138ca715fc3207ef86358a56bd49ebd2d3ba27169c09d1
 ifneq "$(SYFT_CMD_VER)" "$(SYFT_VERSION)"
 	SYFT=docker run --rm \
 		-v "$(shell pwd)/:$(shell pwd)/" -w "$(shell pwd)" \

--- a/build/Dockerfile.olareg
+++ b/build/Dockerfile.olareg
@@ -1,6 +1,6 @@
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
-ARG GO_VER=1.21.6-alpine@sha256:a6a7f1fcf12f5efa9e04b1e75020931a616cd707f14f62ab5262bfbe109aa84a
+ARG GO_VER=1.22.0-alpine@sha256:8e96e6cff6a388c2f70f5f662b64120941fcd7d4b89d62fec87520323a316bd9
 
 FROM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/build/Dockerfile.olareg.buildkit
+++ b/build/Dockerfile.olareg.buildkit
@@ -2,7 +2,7 @@
 
 ARG REGISTRY=docker.io
 ARG ALPINE_VER=3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
-ARG GO_VER=1.21.6-alpine@sha256:a6a7f1fcf12f5efa9e04b1e75020931a616cd707f14f62ab5262bfbe109aa84a
+ARG GO_VER=1.22.0-alpine@sha256:8e96e6cff6a388c2f70f5f662b64120941fcd7d4b89d62fec87520323a316bd9
 
 FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
 RUN apk add --no-cache \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/olareg/olareg
 
-go 1.19
+go 1.20
 
 require (
 	github.com/opencontainers/go-digest v1.0.0


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Version bump:

- Go to 1.22, 1.19 support dropped
- actions/upload-artifact to v4.3.1
- github/cocdeql-action to v3.24.0
- govulncheck to v1.0.4
- anchore/syft to v0.104.0
- regclient/actions commit
- Go base image digest

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Go 1.22 support added and 1.19 support dropped.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
