### PR TITLE
Support upload cancel method

### DIFF
--- a/olareg.go
+++ b/olareg.go
@@ -177,6 +177,9 @@ func (s *Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		} else if req.Method == http.MethodGet {
 			s.blobUploadGet(matches[0], matches[1]).ServeHTTP(resp, req)
 			return
+		} else if req.Method == http.MethodDelete {
+			s.blobUploadDelete(matches[0], matches[1]).ServeHTTP(resp, req)
+			return
 		} else {
 			resp.WriteHeader(http.StatusMethodNotAllowed)
 			return


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This supports clients canceling a blob upload, avoiding the need to wait for the upload to timeout and be garbage collected.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

(This test depends on a commit to regctl that will be pushed shortly.)

```shell
echo "hello" | regctl blob put localhost:5002/x --digest sha256:a8e1571c8aece39aa60cd64b3da4694b936887b620ad7e370b270fbdcca9afec -v debug
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Support blob upload delete API.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
