### PR TITLE
Add referrers pagination support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,10 @@ import (
 )
 
 const (
-	manifestLimitDefault = 8388608 // 8MiB
+	manifestLimitDefault       = 1024 * 1024 * 8
+	referrerCacheExpireDefault = time.Minute * 5
+	referrerCacheLimitDefault  = 1000
+	referrersLimitDefault      = 1024 * 1024 * 4
 )
 
 type Store int
@@ -70,7 +73,10 @@ type ConfigAPIBlob struct {
 }
 
 type ConfigAPIReferrer struct {
-	Enabled *bool
+	Enabled         *bool
+	PageCacheExpire time.Duration // time to save pages for a paged response
+	PageCacheLimit  int           // max number of paged responses to keep in memory
+	Limit           int64         // max size of a referrers response (OCI recommends 4MiB)
 }
 
 func (c *Config) SetDefaults() {
@@ -80,6 +86,15 @@ func (c *Config) SetDefaults() {
 	c.API.Referrer.Enabled = boolDefault(c.API.Referrer.Enabled, true)
 	if c.API.Manifest.Limit <= 0 {
 		c.API.Manifest.Limit = manifestLimitDefault
+	}
+	if c.API.Referrer.PageCacheExpire == 0 {
+		c.API.Referrer.PageCacheExpire = referrerCacheExpireDefault
+	}
+	if c.API.Referrer.PageCacheLimit == 0 {
+		c.API.Referrer.PageCacheLimit = referrerCacheLimitDefault
+	}
+	if c.API.Referrer.Limit == 0 {
+		c.API.Referrer.Limit = referrersLimitDefault
 	}
 
 	c.Storage.ReadOnly = boolDefault(c.Storage.ReadOnly, false)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,179 @@
+// Package cache is used to store values with limits.
+// Items are automatically pruned when too many entries are stored, or values become stale.
+package cache
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/olareg/olareg/types"
+)
+
+type Cache[k comparable, v any] struct {
+	mu       sync.Mutex
+	minAge   time.Duration
+	maxAge   time.Duration
+	minCount int
+	maxCount int
+	timer    *time.Timer
+	entries  map[k]*Entry[v]
+}
+
+type Entry[v any] struct {
+	used  time.Time
+	value v
+}
+
+type sortKeys[k comparable] struct {
+	keys   []k
+	lessFn func(a, b k) bool
+}
+
+type conf struct {
+	minAge   time.Duration
+	maxCount int
+}
+
+type CacheOpts func(*conf)
+
+func WithAge(age time.Duration) CacheOpts {
+	return func(c *conf) {
+		c.minAge = age
+	}
+}
+
+func WithCount(count int) CacheOpts {
+	return func(c *conf) {
+		c.maxCount = count
+	}
+}
+
+func New[k comparable, v any](opts ...CacheOpts) *Cache[k, v] {
+	c := conf{}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	maxAge := c.minAge + (c.minAge / 10)
+	minCount := 0
+	if c.maxCount > 0 {
+		minCount = int(float64(c.maxCount) * 0.9)
+	}
+	return &Cache[k, v]{
+		minAge:   c.minAge,
+		maxAge:   maxAge,
+		minCount: minCount,
+		maxCount: c.maxCount,
+		entries:  map[k]*Entry[v]{},
+	}
+}
+
+func (c *Cache[k, v]) Delete(key k) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+	if len(c.entries) == 0 && c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *Cache[k, v]) Set(key k, val v) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = &Entry[v]{
+		used:  time.Now(),
+		value: val,
+	}
+	if len(c.entries) > c.maxCount {
+		c.pruneLocked()
+	} else if c.timer == nil {
+		// prune resets the timer, so this is only needed if the prune wasn't triggered
+		c.timer = time.AfterFunc(c.maxAge, c.prune)
+	}
+}
+
+func (c *Cache[k, v]) Get(key k) (v, error) {
+	if c == nil {
+		var val v
+		return val, types.ErrNotFound
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.entries[key]; ok {
+		if e.used.Add(c.minAge).Before(time.Now()) {
+			// entry expired
+			go c.prune()
+		} else {
+			c.entries[key].used = time.Now()
+			return e.value, nil
+		}
+	}
+	var val v
+	return val, types.ErrNotFound
+}
+
+func (c *Cache[k, v]) prune() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pruneLocked()
+}
+
+func (c *Cache[k, v]) pruneLocked() {
+	// sort key list by last used date
+	keyList := make([]k, 0, len(c.entries))
+	for key := range c.entries {
+		keyList = append(keyList, key)
+	}
+	sk := sortKeys[k]{
+		keys: keyList,
+		lessFn: func(a, b k) bool {
+			return c.entries[a].used.Before(c.entries[b].used)
+		},
+	}
+	sort.Sort(&sk)
+	// prune entries
+	now := time.Now()
+	cutoff := now.Add(c.minAge * -1)
+	nextTime := now
+	delCount := len(keyList) - c.minCount
+	for i, key := range keyList {
+		if i < delCount || c.entries[key].used.Before(cutoff) {
+			delete(c.entries, key)
+		} else {
+			nextTime = c.entries[key].used
+			break
+		}
+	}
+	// set next timer
+	if len(c.entries) > 0 {
+		dur := nextTime.Sub(now) + c.maxAge
+		if c.timer == nil {
+			// this shouldn't be possible
+			c.timer = time.AfterFunc(dur, c.prune)
+		} else {
+			c.timer.Reset(dur)
+		}
+	} else if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (sk *sortKeys[k]) Len() int {
+	return len(sk.keys)
+}
+
+func (sk *sortKeys[k]) Less(i, j int) bool {
+	return sk.lessFn(sk.keys[i], sk.keys[j])
+}
+
+func (sk *sortKeys[k]) Swap(i, j int) {
+	sk.keys[i], sk.keys[j] = sk.keys[j], sk.keys[i]
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,108 @@
+//go:build go1.18
+// +build go1.18
+
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+type testKey struct {
+	i int
+	s string
+}
+
+func TestCache(t *testing.T) {
+	t.Parallel()
+	testData := []string{
+		"a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+		"k", "l", "m", "n", "o", "p", "q", "r", "s", "t",
+	}
+	count := 10
+	pruneCount := int(float64(count) * 1.1)
+	timeout := time.Millisecond * 250
+	timeoutHalf := timeout / 2
+	timePrune := timeout + (timeout / 10)
+	c := New[int, string](WithAge(timeout), WithCount(count))
+	// add entries beyond limit
+	for i, v := range testData {
+		c.Set(i, v)
+	}
+	// delete last 2 entries
+	for i := len(testData) - 2; i < len(testData); i++ {
+		c.Delete(i)
+	}
+	// get entries, verify some deleted
+	pruneCutoff := len(testData) - pruneCount
+	saveCutoff := len(testData) - count
+	checkCutoff := len(testData) - (count / 2)
+	for i, v := range testData {
+		getVal, err := c.Get(i)
+		if i < pruneCutoff || i >= len(testData)-2 {
+			if err == nil {
+				t.Errorf("value found that should have been pruned: %d", i)
+			}
+		} else if i >= saveCutoff && i < len(testData)-2 {
+			if err != nil {
+				t.Errorf("value not found: %d", i)
+			} else if getVal != v {
+				t.Errorf("value mismatch: %d, expect %s, received %s", i, v, getVal)
+			}
+		}
+	}
+	// track used time
+	start := time.Now()
+	// delay to before minAge and check some entries
+	time.Sleep(timeoutHalf)
+	for i, v := range testData {
+		if i >= saveCutoff && i < checkCutoff {
+			getVal, err := c.Get(i)
+			if err != nil {
+				t.Errorf("value not found: %d", i)
+			} else if getVal != v {
+				t.Errorf("value mismatch: %d, expect %s, received %s", i, v, getVal)
+			}
+		}
+	}
+	// delay to after maxAge from 1st used time
+	time.Sleep(timePrune - time.Since(start))
+	for i, v := range testData {
+		getVal, err := c.Get(i)
+		if i >= saveCutoff && i < checkCutoff {
+			if err != nil {
+				t.Errorf("value not found: %d", i)
+			} else if getVal != v {
+				t.Errorf("value mismatch: %d, expect %s, received %s", i, v, getVal)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("value not pruned: %d", i)
+			}
+		}
+	}
+	// delay to after maxAge for all entries
+	time.Sleep(timePrune)
+	for i := range testData {
+		_, err := c.Get(i)
+		if err == nil {
+			t.Errorf("value not pruned: %d", i)
+		}
+	}
+	// set and delete a key
+	c.Set(42, "x")
+	c.Delete(42)
+	// delete non-existent key
+	c.Delete(42)
+
+	// set and get a struct based key
+	c2 := New[testKey, string](WithAge(timeout), WithCount(count))
+	c2.Set(testKey{i: 42, s: "test"}, "value")
+	v, err := c2.Get(testKey{i: 42, s: "test"})
+	if err != nil {
+		t.Errorf("failed to get key: %v", err)
+	}
+	if v != "value" {
+		t.Errorf("value mismatch, expected value, received %s", v)
+	}
+}

--- a/referrer.go
+++ b/referrer.go
@@ -1,11 +1,12 @@
 package olareg
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/opencontainers/go-digest"
 
@@ -19,10 +20,23 @@ const (
 	referrerFilterATHeaderValue = "artifactType"
 )
 
+type referrerKey struct {
+	dig          digest.Digest
+	artifactType string
+}
+
+type referrerResponses [][]byte
+
 // referrerGet searches for the referrers response in the index.
 // All errors should return an empty response, no 404's should be generated.
 func (s *Server) referrerGet(repoStr, arg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		filterAT := r.URL.Query().Get(referrerFilterATParam)
+		cacheDig := r.URL.Query().Get("cache")
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page < 0 {
+			page = 0
+		}
 		// most errors should return an empty index
 		i := types.Index{
 			SchemaVersion: 2,
@@ -39,6 +53,32 @@ func (s *Server) referrerGet(repoStr, arg string) http.HandlerFunc {
 			return
 		}
 		defer repo.Done()
+		if cacheDig != "" && page != 0 {
+			dig, err := digest.Parse(cacheDig)
+			if err != nil {
+				s.log.Info("paged referrers request for invalid cache digest", "cache", cacheDig, "repo", repoStr, "page", page)
+				w.WriteHeader(http.StatusBadRequest)
+				_ = types.ErrRespJSON(w, types.ErrInfoUnsupported("requested digest is not valid"))
+				return
+			}
+			if cacheResp, err := s.referrerCache.Get(referrerKey{dig: dig, artifactType: filterAT}); err == nil && page < len(cacheResp) {
+				if page+1 < len(cacheResp) {
+					next := r.URL
+					q := next.Query()
+					q.Set("page", fmt.Sprintf("%d", page+1))
+					next.RawQuery = q.Encode()
+					w.Header().Add("Link", fmt.Sprintf("<%s>; rel=next", next.String()))
+				}
+				w.Header().Add("content-type", types.MediaTypeOCI1ManifestList)
+				w.WriteHeader(http.StatusOK)
+				_, err = w.Write(cacheResp[page])
+				if err != nil {
+					s.log.Info("failed to write referrers response", "err", err, "repo", repoStr, "arg", arg)
+				}
+				return
+			}
+			// cache search for paged data failed, regenerate from current state, only use page counter if digest matches
+		}
 		index, err := repo.IndexGet()
 		if err != nil {
 			w.Header().Add("content-type", types.MediaTypeOCI1ManifestList)
@@ -59,6 +99,26 @@ func (s *Server) referrerGet(repoStr, arg string) http.HandlerFunc {
 			_ = json.NewEncoder(w).Encode(i)
 			return
 		}
+		// check page cache for digest, two users requesting same referrer list
+		if cacheResp, err := s.referrerCache.Get(referrerKey{dig: d.Digest, artifactType: filterAT}); err == nil {
+			if page >= len(cacheResp) {
+				page = 0
+			}
+			if page+1 < len(cacheResp) {
+				next := r.URL
+				q := next.Query()
+				q.Set("cache", d.Digest.String())
+				q.Set("page", fmt.Sprintf("%d", page+1))
+				next.RawQuery = q.Encode()
+				w.Header().Add("Link", fmt.Sprintf("<%s>; rel=next", next.String()))
+			}
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(cacheResp[page])
+			if err != nil {
+				s.log.Info("failed to write referrers response", "err", err, "repo", repoStr, "arg", arg)
+			}
+			return
+		}
 		rdr, err := repo.BlobGet(d.Digest)
 		if err != nil {
 			w.WriteHeader(http.StatusOK)
@@ -66,10 +126,14 @@ func (s *Server) referrerGet(repoStr, arg string) http.HandlerFunc {
 			s.log.Info("failed to get referrers response", "err", err, "repo", repoStr, "arg", arg, "digest", d.Digest.String())
 			return
 		}
-		defer rdr.Close()
-		var out io.Reader
-		out = rdr
-		filterAT := r.URL.Query().Get(referrerFilterATParam)
+		out, err := io.ReadAll(rdr)
+		_ = rdr.Close()
+		if err != nil {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(i)
+			s.log.Info("failed to read referrers response", "err", err, "repo", repoStr, "arg", arg, "digest", d.Digest.String())
+			return
+		}
 		if filterAT != "" {
 			out, err = referrerFilter(out, filterAT)
 			if err != nil {
@@ -80,8 +144,36 @@ func (s *Server) referrerGet(repoStr, arg string) http.HandlerFunc {
 			}
 			w.Header().Add(referrerFilterATHeaderKey, referrerFilterATHeaderValue)
 		}
+		if int64(len(out)) > s.conf.API.Referrer.Limit {
+			// split the response if necessary
+			split, err := referrerSplit(out, s.conf.API.Referrer.Limit)
+			if err != nil {
+				s.log.Info("failed splitting referrer list", "err", err, "repo", repoStr, "arg", arg, "digest", d.Digest.String())
+			}
+			if len(split) == 0 {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(i)
+				return
+			}
+			// cache the split
+			s.referrerCache.Set(referrerKey{dig: d.Digest, artifactType: filterAT}, split)
+			// set the requested page output and next link
+			if page > 0 && (cacheDig != d.Digest.String() || page >= len(split)) {
+				page = 0
+			}
+			if page+1 < len(split) {
+				next := r.URL
+				q := next.Query()
+				q.Set("cache", d.Digest.String())
+				q.Set("page", fmt.Sprintf("%d", page+1))
+				next.RawQuery = q.Encode()
+				w.Header().Add("Link", fmt.Sprintf("<%s>; rel=next", next.String()))
+			}
+			out = split[page]
+		}
+		w.Header().Add("content-length", fmt.Sprintf("%d", len(out)))
 		w.WriteHeader(http.StatusOK)
-		_, err = io.Copy(w, out)
+		_, err = w.Write(out)
 		if err != nil {
 			s.log.Info("failed to write referrers response", "err", err, "repo", repoStr, "arg", arg)
 		}
@@ -89,9 +181,9 @@ func (s *Server) referrerGet(repoStr, arg string) http.HandlerFunc {
 }
 
 // referrerFilter applies a filter to the returned descriptor list
-func referrerFilter(rdr io.Reader, filterArtifactType string) (io.Reader, error) {
+func referrerFilter(inBytes []byte, filterArtifactType string) ([]byte, error) {
 	in := types.Index{}
-	err := json.NewDecoder(rdr).Decode(&in)
+	err := json.Unmarshal(inBytes, &in)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +204,57 @@ func referrerFilter(rdr io.Reader, filterArtifactType string) (io.Reader, error)
 	if err != nil {
 		return nil, err
 	}
-	return bytes.NewReader(outBytes), nil
+	return outBytes, nil
+}
+
+// referrerSplit separates a referrer index into separate pages.
+// This will fail if a single entry still exceeds the limit.
+// Note this is designed for readability over efficiency.
+func referrerSplit(inBytes []byte, limit int64) ([][]byte, error) {
+	in := types.Index{}
+	err := json.Unmarshal(inBytes, &in)
+	if err != nil {
+		return nil, err
+	}
+	result := [][]byte{}
+	last := []byte{}
+	cur := types.Index{
+		SchemaVersion: in.SchemaVersion,
+		MediaType:     in.MediaType,
+		ArtifactType:  in.ArtifactType,
+		Annotations:   in.Annotations,
+		Manifests:     []types.Descriptor{},
+		Subject:       in.Subject,
+	}
+	errs := []error{}
+	for _, d := range in.Manifests {
+		cur.Manifests = append(cur.Manifests, d)
+		next, err := json.Marshal(cur)
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(next)) > limit {
+			result = append(result, last)
+			cur.Manifests = []types.Descriptor{d}
+			next, err = json.Marshal(cur)
+			if err != nil {
+				return nil, err
+			}
+			if int64(len(next)) > limit {
+				errs = append(errs, fmt.Errorf("single descriptor greater than limit: %s", d.Digest))
+				cur.Manifests = []types.Descriptor{}
+				last = nil
+			}
+		}
+		last = next
+	}
+	if last != nil {
+		result = append(result, last)
+	}
+	if len(errs) > 0 {
+		return result, errors.Join(errs...)
+	}
+	return result, nil
 }
 
 // referrerAdd adds a new referrer entry to a given subject.
@@ -133,12 +275,8 @@ func (s *Server) referrerAdd(repo store.Repo, subject digest.Digest, desc types.
 			if err != nil {
 				return
 			}
-			iRaw, err := io.ReadAll(rdr)
+			err = json.NewDecoder(rdr).Decode(&refResp)
 			_ = rdr.Close()
-			if err != nil {
-				return
-			}
-			err = json.Unmarshal(iRaw, &refResp)
 			if err != nil {
 				return
 			}

--- a/tag.go
+++ b/tag.go
@@ -54,7 +54,7 @@ func (s *Server) tagList(repoStr string) http.HandlerFunc {
 				q := next.Query()
 				q.Set("last", tl.Tags[len(tl.Tags)-1])
 				next.RawQuery = q.Encode()
-				w.Header().Add("Link", fmt.Sprintf("%s; rel=next", next.String()))
+				w.Header().Add("Link", fmt.Sprintf("<%s>; rel=next", next.String()))
 			}
 		}
 		tlJSON, err := json.Marshal(tl)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This supports pagination of referrers. It also adds a generic cache that can be useful for other requests like open repositories and blob upload sessions.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Push multiple referrers with enough descriptor content (e.g. very large annotations) to exceed the 4MiB manifest size limit on a referrers response. The response will then trigger a link header with the next page of responses.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add support for referrers response pagination.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
