### PR TITLE
Update annotation to not use OCI values before approval

### DIFF
--- a/types/annotations.go
+++ b/types/annotations.go
@@ -5,7 +5,7 @@ const (
 	AnnotRefName = "org.opencontainers.image.ref.name"
 	// AnnotReferrerSubject is used on descriptors that point to the referrer response in an OCI layout index.json.
 	// The value is the digest of the subject.
-	AnnotReferrerSubject = "org.opencontainers.image.referrer.subject"
+	AnnotReferrerSubject = "org.olareg.referrer.subject"
 	// AnnotReferrerConvert is set to true to indicate any referrers in the OCI Layout pushed with the fallback tag have been converted to the referrer.subject annotation.
-	AnnotReferrerConvert = "org.opencontainers.image.referrer.convert"
+	AnnotReferrerConvert = "org.olareg.referrer.convert"
 )


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Annotations for the referrer have not been approved by OCI, so switch to project specific values.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Pushing images with referrers will now use new annotations.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Use project specific annotations for referrers.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
