### PR TITLE
Fix permissions needed for GHA coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
     # When you execute your unit tests, make sure to use the "-coverprofile" flag to write a 
     # coverage profile to a file. You will need the name of the file (e.g. "coverage.txt")
     # in the next step as well as the next job.
-    - name: Test
+    - name: Generate coverage
       run: go test -cover -coverprofile=coverage.txt ./...
 
     - name: Archive code coverage results
@@ -46,8 +46,16 @@ jobs:
         name: code-coverage
         path: coverage.txt
 
-    - name: Generate coverage report
-      if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
+  pr_comment:
+    name: "Comment on PR"
+    if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
+    runs-on: ubuntu-latest
+    needs: coverage_report
+    permissions:
+      pull-requests: write # write permission needed to comment on PR
+
+    steps:
+    - name: Comment on PR
       uses: fgrosse/go-coverage-report@a284a4c69b3383da62629009e9e8e58976efbf6a # v1.0.0
       continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
       with:


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The coverage report is not writing to the PR.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds the needed permissions, and separates the jobs to give the permission to the fewest steps.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

PR should show a coverage report.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Fix coverage report generator.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
