### PR TITLE
Override Go versions for the OSV Scanner and disable

### DIFF
--- a/.github/workflows/vulnscans.yml
+++ b/.github/workflows/vulnscans.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  govunlcheck:
-    name: Go Vuln Check
+  vulnerability-scans:
+    name: Run vulnerability scans
     runs-on: ubuntu-latest
     env:
       RELEASE_GO_VER: "1.22"
@@ -25,6 +25,7 @@ jobs:
         go-version: "${{ env.RELEASE_GO_VER }}"
         check-latest: true
 
+    # intentionally not pinned to always run the latest scanner
     - name: "Install govulncheck"
       run: |
         go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -33,10 +34,12 @@ jobs:
       run: |
         govulncheck ./...
 
-    - name: "Install OSV Scanner"
-      run: |
-        go install github.com/google/osv-scanner/cmd/osv-scanner@latest
+    # TODO: reenable after 1.7.2 or later is released
+    # intentionally not pinned to always run the latest scanner
+    # - name: "Install OSV Scanner"
+    #   run: |
+    #     go install github.com/google/osv-scanner/cmd/osv-scanner@latest
 
-    - name: "Run OSV Scanner"
-      run: |
-        osv-scanner -r --experimental-licenses="Apache-2.0,BSD-3-Clause,MIT,CC-BY-SA-4.0,UNKNOWN" .
+    # - name: "Run OSV Scanner"
+    #   run: |
+    #     osv-scanner --config .osv-scanner.toml -r --experimental-licenses="Apache-2.0,BSD-3-Clause,MIT,CC-BY-SA-4.0,UNKNOWN" .

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -1,0 +1,1 @@
+GoVersionOverride = "1.22.1"

--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -36,6 +36,9 @@ files:
   "go.mod":
     scans:
       - go-mod-golang-release
+  ".osv-scanner.toml":
+    scans:
+      - osv-golang-release
 
 scans:
   docker-arg-alpine-tag:
@@ -174,6 +177,12 @@ scans:
     source: "registry-digest-match"
     args:
       regexp: '^SYFT_CONTAINER\?=(?P<Image>[^:]*):(?P<Tag>v[0-9\.]+)@(?P<Version>sha256:[0-9a-f]+)\s*$'
+  osv-golang-release:
+    type: "regexp"
+    source: "registry-tag-arg-semver"
+    args:
+      regexp: '^GoVersionOverride = "(?P<Version>[0-9\.]+)"\s*$'
+      repo: "docker.io/library/golang"
   shell-alpine-tag:
     type: "regexp"
     source: "registry-tag-arg-semver-major"

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ vulnerability-scan: osv-scanner vulncheck-go ## Run all vulnerability scanners
 
 .PHONY: osv-scanner
 osv-scanner: $(GOPATH)/bin/osv-scanner .FORCE ## Run OSV Scanner
-	$(GOPATH)/bin/osv-scanner scan -r --experimental-licenses="Apache-2.0,BSD-3-Clause,MIT,CC-BY-SA-4.0,UNKNOWN" .
+	$(GOPATH)/bin/osv-scanner scan --config .osv-scanner.toml -r --experimental-licenses="Apache-2.0,BSD-3-Clause,MIT,CC-BY-SA-4.0,UNKNOWN" .
 
 .PHONY: vulncheck-go
 vulncheck-go: $(GOPATH)/bin/govulncheck .FORCE ## Run govulncheck


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Updates the OSV Scanner to use an override file for the Go version.
The scan is also disabled pending the next release that uses the override file.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

GHA will stop failing.
<!-- Include steps that can be taken to verify the change -->

### Changelog text


- Fix: Override the Go version used by the OSV Scanner.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
