### PR TITLE
Set workdir and volume in Dockerfile

### DIFF
--- a/build/Dockerfile.olareg
+++ b/build/Dockerfile.olareg
@@ -8,7 +8,7 @@ RUN apk add --no-cache \
       git \
       make
 RUN adduser -D appuser \
- && mkdir -p /home/appuser \
+ && mkdir -p /home/appuser/registry \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
@@ -26,6 +26,8 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=appuser /home/appuser /home/appuser
 COPY --from=build /src/bin/olareg /usr/local/bin/olareg
 USER appuser
+VOLUME /home/appuser/registry
+WORKDIR /home/appuser/registry
 CMD [ "olareg", "--help" ]
 
 ARG BUILD_DATE
@@ -51,6 +53,8 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=appuser /home/appuser /home/appuser
 COPY --from=build /src/bin/olareg /olareg
 USER appuser
+VOLUME /home/appuser/registry
+WORKDIR /home/appuser/registry
 ENTRYPOINT [ "/olareg" ]
 
 ARG BUILD_DATE

--- a/build/Dockerfile.olareg.buildkit
+++ b/build/Dockerfile.olareg.buildkit
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
       make
 RUN addgroup -g 1000 appuser \
  && adduser -u 1000 -G appuser -D appuser \
- && mkdir -p /home/appuser \
+ && mkdir -p /home/appuser/registry \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
@@ -40,6 +40,8 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
 COPY --from=build /src/bin/olareg /usr/local/bin/olareg
 USER appuser
+VOLUME /home/appuser/registry
+WORKDIR /home/appuser/registry
 CMD [ "olareg", "--help" ]
 
 ARG BUILD_DATE
@@ -65,6 +67,8 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
 COPY --from=build /src/bin/olareg /olareg
 USER appuser
+VOLUME /home/appuser/registry
+WORKDIR /home/appuser/registry
 ENTRYPOINT [ "/olareg" ]
 
 ARG BUILD_DATE


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Running a registry in a container with `docker run --rm ghcr.io/olareg/olareg:latest serve` fails because of a read only directory.

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Set the workdir to be the writable home directory. The directory is also defined as a volume to persist the data by default. This allows the registry to run using the default options.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
docker run --rm -p 5000:5000 ghcr.io/olareg/olareg:edge serve
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Set `workdir` and `volume` in Dockerfile.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
