### PR TITLE
Add tests and example text for olareg serve command

### DIFF
--- a/cmd/olareg/olareg_test.go
+++ b/cmd/olareg/olareg_test.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 type cobraTestOpts struct {
-	stdin io.Reader
+	stdin   io.Reader
+	timeout time.Duration
 }
 
 func cobraTest(t *testing.T, opts *cobraTestOpts, args ...string) (string, error) {
@@ -17,8 +20,15 @@ func cobraTest(t *testing.T, opts *cobraTestOpts, args ...string) (string, error
 
 	buf := new(bytes.Buffer)
 	cmd := newRootCmd()
-	if opts != nil && opts.stdin != nil {
-		cmd.SetIn(opts.stdin)
+	if opts != nil {
+		if opts.stdin != nil {
+			cmd.SetIn(opts.stdin)
+		}
+		if opts.timeout > 0 {
+			ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
+			defer cancel()
+			cmd.SetContext(ctx)
+		}
 	}
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)

--- a/cmd/olareg/serve_test.go
+++ b/cmd/olareg/serve_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServe(t *testing.T) {
+	timeout := time.Millisecond * 250
+	tt := []struct {
+		name        string
+		args        []string
+		expectErr   error
+		expectOut   string
+		outContains bool
+	}{
+		{
+			name: "no-args",
+			args: []string{"serve"},
+		},
+		{
+			name:      "unknown-store",
+			args:      []string{"serve", "--store-type", "unknown"},
+			expectErr: fmt.Errorf(`unable to parse store type unknown: unknown store value "unknown"`),
+		},
+		{
+			name: "port",
+			args: []string{"serve", "--port", "12345"},
+		},
+	}
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := cobraTest(t, &cobraTestOpts{timeout: timeout}, tc.args...)
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("did not receive expected error: %v", tc.expectErr)
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("unexpected error, received %v, expected %v", err, tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				var netErr *net.OpError
+				if errors.As(err, &netErr) && netErr.Op == "listen" {
+					t.Skipf("skipping, unable to listen: %v", err)
+				}
+				t.Fatalf("returned unexpected error: %v", err)
+			}
+			if (!tc.outContains && out != tc.expectOut) || (tc.outContains && !strings.Contains(out, tc.expectOut)) {
+				t.Errorf("unexpected output, expected %s, received %s", tc.expectOut, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

There's little documentation on how to use `olareg serve`. There's also a race between `olareg.Run` and `olareg.Shutdown`.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds tests and example text for the `olareg serve` command. It also fixes a small race condition discovered by the tests.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
olareg serve --help
make test
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Doc: Add example text for `olareg serve` command.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
