### PR TITLE
Use cache for blob uploads in mem store

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -115,4 +115,8 @@ func TestCache(t *testing.T) {
 	if v != "value" {
 		t.Errorf("value mismatch, expected value, received %s", v)
 	}
+	c2.DeleteAll()
+	if len(c2.entries) > 0 {
+		t.Errorf("entries remain after DeleteAll")
+	}
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This removes the custom upload cache management to leverage the cache package in the mem store.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Push an image to the a registry using the mem store.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Refactor blob upload in the mem store to use the cache package.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
