### PR TITLE
Configurable limit on concurrent uploads

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ const (
 	referrerCacheExpireDefault = time.Minute * 5
 	referrerCacheLimitDefault  = 1000
 	referrersLimitDefault      = 1024 * 1024 * 4
+	repoUploadMaxDefault       = 1000
 )
 
 type Store int
@@ -50,6 +51,7 @@ type ConfigStorage struct {
 type ConfigGC struct {
 	Frequency         time.Duration // frequency to run garbage collection, disable gc with a negative value
 	GracePeriod       time.Duration // time to preserve recently pushed manifests and blobs, disable with a negative value
+	RepoUploadMax     int           // limit on number of concurrent uploads to a repository, unlimited with a negative value
 	Untagged          *bool         // delete untagged manifests
 	EmptyRepo         *bool         // delete empty repo
 	ReferrersDangling *bool         // delete referrers when manifest does not exist
@@ -109,6 +111,9 @@ func (c *Config) SetDefaults() {
 	}
 	if c.Storage.GC.GracePeriod == 0 {
 		c.Storage.GC.GracePeriod = time.Hour
+	}
+	if c.Storage.GC.RepoUploadMax == 0 {
+		c.Storage.GC.RepoUploadMax = repoUploadMaxDefault
 	}
 	c.Storage.GC.Untagged = boolDefault(c.Storage.GC.Untagged, false)
 	c.Storage.GC.EmptyRepo = boolDefault(c.Storage.GC.EmptyRepo, true)

--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -90,8 +90,10 @@ func (m *mem) RepoGet(repoStr string) (Repo, error) {
 		return mr, nil
 	}
 	uploadCacheOpts := []cache.CacheOpts[string, *memRepoUpload]{
-		cache.WithCount[string, *memRepoUpload](1000),
 		cache.WithPrune(func(_ string, mru *memRepoUpload) { mru.buffer.Truncate(0) }),
+	}
+	if m.conf.Storage.GC.RepoUploadMax > 0 {
+		uploadCacheOpts = append(uploadCacheOpts, cache.WithCount[string, *memRepoUpload](m.conf.Storage.GC.RepoUploadMax))
 	}
 	if m.conf.Storage.GC.GracePeriod > 0 {
 		uploadCacheOpts = append(uploadCacheOpts, cache.WithAge[string, *memRepoUpload](m.conf.Storage.GC.GracePeriod))


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a configuration option for the number of concurrent uploads to a repository. It currently only supports the mem store type.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Attempt to run too many concurrent uploads, oldest uploads without any activity will be dropped.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add a configurable limit on the number of concurrent uploads to a repository.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

Tests will be added when the dir store is updated, allowing the same tests to be run on both.
<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
