### PR TITLE
Use cache for uploads in dir store

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -19,8 +19,9 @@ func TestCache(t *testing.T) {
 		"a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
 		"k", "l", "m", "n", "o", "p", "q", "r", "s", "t",
 	}
-	count := 10
-	pruneCount := int(float64(count) * 1.1)
+	countMax := 10
+	countMin := int(float64(countMax) * 0.9)
+	countDel := 2
 	pruned := map[string]bool{}
 	pruneFn := func(_ int, v string) {
 		pruned[v] = true
@@ -28,29 +29,32 @@ func TestCache(t *testing.T) {
 	timeout := time.Millisecond * 250
 	timeoutHalf := timeout / 2
 	timePrune := timeout + (timeout / 10)
-	c := New[int, string](WithAge[int, string](timeout), WithCount[int, string](count), WithPrune[int, string](pruneFn))
+	c := New[int, string](WithAge[int, string](timeout), WithCount[int, string](countMax), WithPrune[int, string](pruneFn))
 	// add entries beyond limit
 	for i, v := range testData {
 		c.Set(i, v)
 	}
 	// delete last 2 entries
-	for i := len(testData) - 2; i < len(testData); i++ {
+	for i := len(testData) - countDel; i < len(testData); i++ {
 		c.Delete(i)
 	}
+	if c.IsEmpty() {
+		t.Errorf("cache is empty after adding entries")
+	}
 	// get entries, verify some deleted
-	pruneCutoff := len(testData) - pruneCount
-	saveCutoff := len(testData) - count
-	checkCutoff := len(testData) - (count / 2)
+	pruneCutoff := len(testData) - countMax
+	saveCutoff := len(testData) - countMin
+	checkCutoff := len(testData) - (countMax / 2)
 	for i, v := range testData {
 		getVal, err := c.Get(i)
-		if i < pruneCutoff || i >= len(testData)-2 {
+		if i < pruneCutoff || i >= len(testData)-countDel {
 			if !pruned[v] {
 				t.Errorf("value not found on pruned map: %s", v)
 			}
 			if err == nil {
 				t.Errorf("value found that should have been pruned: %d", i)
 			}
-		} else if i >= saveCutoff && i < len(testData)-2 {
+		} else if i >= saveCutoff && i < len(testData)-countDel {
 			if pruned[v] {
 				t.Errorf("value found on pruned map: %s", v)
 			}
@@ -60,6 +64,12 @@ func TestCache(t *testing.T) {
 				t.Errorf("value mismatch: %d, expect %s, received %s", i, v, getVal)
 			}
 		}
+	}
+	entries, err := c.List()
+	if err != nil {
+		t.Errorf("failed listing entries: %v", err)
+	} else if len(entries) < countMin-countDel || len(entries) > countMax {
+		t.Errorf("unexpected length of entries: %d not between %d and %d", len(entries), countMin-countDel, countMax)
 	}
 	// track used time
 	start := time.Now()
@@ -92,12 +102,15 @@ func TestCache(t *testing.T) {
 		}
 	}
 	// delay to after maxAge for all entries
-	time.Sleep(timePrune)
+	time.Sleep(timePrune + timePrune/5)
 	for i := range testData {
 		_, err := c.Get(i)
 		if err == nil {
 			t.Errorf("value not pruned: %d", i)
 		}
+	}
+	if !c.IsEmpty() {
+		t.Errorf("cache is not empty after prune time")
 	}
 	// set and delete a key
 	c.Set(42, "x")
@@ -106,7 +119,7 @@ func TestCache(t *testing.T) {
 	c.Delete(42)
 
 	// set and get a struct based key
-	c2 := New[testKey, string](WithAge[testKey, string](timeout), WithCount[testKey, string](count))
+	c2 := New[testKey, string](WithAge[testKey, string](timeout), WithCount[testKey, string](countMax))
 	c2.Set(testKey{i: 42, s: "test"}, "value")
 	v, err := c2.Get(testKey{i: 42, s: "test"})
 	if err != nil {
@@ -115,8 +128,14 @@ func TestCache(t *testing.T) {
 	if v != "value" {
 		t.Errorf("value mismatch, expected value, received %s", v)
 	}
+	if c2.IsEmpty() {
+		t.Errorf("cache is empty before deleting entries")
+	}
 	c2.DeleteAll()
 	if len(c2.entries) > 0 {
 		t.Errorf("entries remain after DeleteAll")
+	}
+	if !c.IsEmpty() {
+		t.Errorf("cache is not empty after deleting entries")
 	}
 }

--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -505,8 +505,7 @@ func (mru *memRepoUpload) Write(p []byte) (int, error) {
 	mru.mr.mu.Lock()
 	defer mru.mr.mu.Unlock()
 	// verify session still exists and update last write time
-	_, err := mru.mr.uploads.Get(mru.sessionID)
-	if err != nil {
+	if _, err := mru.mr.uploads.Get(mru.sessionID); err != nil {
 		return 0, fmt.Errorf("session expired %s: %w", mru.sessionID, err)
 	}
 	return mru.w.Write(p)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Refactors the upload session handling for the dir store to use the cache package.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Pushing too many concurrent uploads will drop the oldest ones (based on the last write).
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Refactor uploads in the dir store to use the cache package, allowing limits per repo.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
