### PR TITLE
Add SIGUSR1 handler to output stack trace

### DIFF
--- a/cmd/olareg/serve.go
+++ b/cmd/olareg/serve.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/olareg/olareg"
 	"github.com/olareg/olareg/config"
+	"github.com/olareg/olareg/internal/godbg"
 )
 
 type serveOpts struct {
@@ -117,6 +118,7 @@ func (opts *serveOpts) run(cmd *cobra.Command, args []string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	godbg.SignalTrace()
 	ctx, cancel := context.WithCancel(ctx)
 	cleanShutdown := make(chan struct{})
 	go func() {

--- a/internal/godbg/godbg_other.go
+++ b/internal/godbg/godbg_other.go
@@ -1,0 +1,10 @@
+//go:build windows
+// +build windows
+
+package godbg
+
+import "os"
+
+func SignalTrace(sigs ...os.Signal) {
+	// SignalTrace is not implemented on windows
+}

--- a/internal/godbg/godbg_unix.go
+++ b/internal/godbg/godbg_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+// +build !windows
+
+// Package godbg provides tooling for debugging Go
+package godbg
+
+import (
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"syscall"
+)
+
+func SignalTrace(sigs ...os.Signal) {
+	if len(sigs) == 0 {
+		sigs = append(sigs, syscall.SIGUSR1)
+	}
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, sigs...)
+	go func() {
+		<-sig
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+	}()
+}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds a signal handler on SIGUSR1 to output a stack trace. This makes it easier to debug deadlock situations.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
olareg serve --store-type mem &
kill -SIGUSR1 $!
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Add SIGUSR1 handler to output a stack trace.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
