### PR TITLE
Feat: Use caching for repositories in dir store

### DIFF
--- a/olareg.go
+++ b/olareg.go
@@ -31,10 +31,10 @@ func New(conf config.Config) *Server {
 	s := &Server{
 		conf: conf,
 		log:  conf.Log,
-		referrerCache: cache.New[referrerKey, referrerResponses](
-			cache.WithAge[referrerKey, referrerResponses](conf.API.Referrer.PageCacheExpire),
-			cache.WithCount[referrerKey, referrerResponses](conf.API.Referrer.PageCacheLimit),
-		),
+		referrerCache: cache.New[referrerKey, referrerResponses](cache.Opts[referrerKey, referrerResponses]{
+			Age:   conf.API.Referrer.PageCacheExpire,
+			Count: conf.API.Referrer.PageCacheLimit,
+		}),
 	}
 	if s.log == nil {
 		s.log = slog.Null{}

--- a/tag.go
+++ b/tag.go
@@ -25,8 +25,8 @@ func (s *Server) tagList(repoStr string) http.HandlerFunc {
 			s.log.Info("failed to get repo", "err", err, "repo", repoStr)
 			return
 		}
-		defer repo.Done()
 		index, err := repo.IndexGet()
+		repo.Done()
 		if err != nil {
 			// TODO: handle different errors (perm denied, not found, internal server error)
 			w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

There is a lot of refactoring happening here, with more planned in the future. In this change:

- Cache prune function can now reject with an error.
- Cache options refactored to be a struct rather than option args.
- Locking refactored on repo to prevent wg.Wait when a wg.Add could also run.
- Garbage collection refactored to stop all repo actions.
- Repo cache in the dir store frees up memory when the repo is no longer being accessed.
- Repo locking is minimized in blob and tag APIs.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This is a large refactoring under the covers, so end user experience should be unchanged, but memory usage of the dir store should be reduced for long running registries with a lot of repositories.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Use caching for repositories in dir store
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
