### PR TITLE
Breaking: Disable delete APIs by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,18 +167,18 @@ oci-conformance: ci-setup ci-oci-conformance ci-cleanup ## Run OCI Conformance
 .PHONY: ci-setup
 ci-setup: docker-olareg
 	docker rm -f olareg-ci || true
-	docker run --rm -d --name olareg-ci -p 5000 olareg/olareg serve
+	docker run --rm -d --name olareg-ci -p 5000 olareg/olareg serve --api-delete
 
 .PHONY: ci-oci-conformance
 ci-oci-conformance:
 	docker run \
 		--rm --net container:olareg-ci \
 		-e OCI_ROOT_URL="http://localhost:5000" \
-  	-e OCI_NAMESPACE="myorg/myrepo" \
+		-e OCI_NAMESPACE="myorg/myrepo" \
 		-e OCI_TEST_PULL=1 \
 		-e OCI_TEST_PUSH=1 \
-  	-e OCI_TEST_CONTENT_DISCOVERY=1 \
-  	-e OCI_TEST_CONTENT_MANAGEMENT=1 \
+		-e OCI_TEST_CONTENT_DISCOVERY=1 \
+		-e OCI_TEST_CONTENT_MANAGEMENT=1 \
 		ghcr.io/opencontainers/distribution-spec/conformance:main
 
 # TODO: add CI tests with regclient, crane, skopeo, oras, and docker

--- a/cmd/olareg/serve.go
+++ b/cmd/olareg/serve.go
@@ -69,7 +69,7 @@ olareg serve --tls-cert host.pem --tls-key host.key --port 443
 	newCmd.Flags().StringVar(&opts.storeType, "store-type", "dir", "storage type (dir, mem)")
 	newCmd.Flags().BoolVar(&opts.storeRO, "store-ro", false, "restrict storage as read-only")
 	newCmd.Flags().BoolVar(&opts.apiPush, "api-push", true, "enable push APIs")
-	newCmd.Flags().BoolVar(&opts.apiDelete, "api-delete", true, "enable delete APIs")
+	newCmd.Flags().BoolVar(&opts.apiDelete, "api-delete", false, "enable delete APIs")
 	newCmd.Flags().BoolVar(&opts.apiBlobDel, "api-blob-delete", false, "enable blob delete API")
 	newCmd.Flags().BoolVar(&opts.apiReferrer, "api-referrer", true, "enable referrer API")
 	newCmd.Flags().DurationVar(&opts.gcFreq, "gc-frequency", time.Minute*15, "garbage collection frequency")

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ type ConfigAPIReferrer struct {
 }
 
 func (c *Config) SetDefaults() {
-	c.API.DeleteEnabled = boolDefault(c.API.DeleteEnabled, true)
+	c.API.DeleteEnabled = boolDefault(c.API.DeleteEnabled, false)
 	c.API.PushEnabled = boolDefault(c.API.PushEnabled, true)
 	c.API.Blob.DeleteEnabled = boolDefault(c.API.Blob.DeleteEnabled, false)
 	c.API.Referrer.Enabled = boolDefault(c.API.Referrer.Enabled, true)

--- a/olareg_test.go
+++ b/olareg_test.go
@@ -68,6 +68,7 @@ func TestServer(t *testing.T) {
 					StoreType: config.StoreMem,
 				},
 				API: config.ConfigAPI{
+					DeleteEnabled: &boolT,
 					Referrer: config.ConfigAPIReferrer{
 						Limit: 512 * 1024,
 					},
@@ -82,6 +83,7 @@ func TestServer(t *testing.T) {
 					RootDir:   "./testdata",
 				},
 				API: config.ConfigAPI{
+					DeleteEnabled: &boolT,
 					Referrer: config.ConfigAPIReferrer{
 						Limit: 512 * 1024,
 					},
@@ -101,6 +103,7 @@ func TestServer(t *testing.T) {
 					},
 				},
 				API: config.ConfigAPI{
+					DeleteEnabled: &boolT,
 					Referrer: config.ConfigAPIReferrer{
 						Limit: 512 * 1024,
 					},
@@ -118,6 +121,7 @@ func TestServer(t *testing.T) {
 					ReadOnly:  &boolT,
 				},
 				API: config.ConfigAPI{
+					DeleteEnabled: &boolT,
 					Referrer: config.ConfigAPIReferrer{
 						Limit: 512 * 1024,
 					},


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This leaves the delete APIs disabled by default. Leaving these APIs enabled by default could be dangerous.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Run a registry and attempt to delete content with the default options.
```shell
olareg serve --port 5002 &
regctl image copy localhost:5000/regclient/regctl localhost:5002/regclient/regctl
regctl tag rm localhost:5002/regclient/regctl # this should fail
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Breaking: Disable delete APIs by default
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
