### PR TITLE
Feat: Debug logs on store changes

### DIFF
--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -252,6 +252,7 @@ func (mr *memRepo) IndexInsert(desc types.Descriptor, opts ...types.IndexOpt) er
 	mr.timeMod = time.Now()
 	mr.index.AddDesc(desc, opts...)
 	mr.mu.Unlock()
+	mr.log.Debug("index entry added", "repo", mr.path, "desc", desc)
 	return nil
 }
 
@@ -264,6 +265,7 @@ func (mr *memRepo) IndexRemove(desc types.Descriptor) error {
 	mr.timeMod = time.Now()
 	mr.index.RmDesc(desc)
 	mr.mu.Unlock()
+	mr.log.Debug("index entry removed", "repo", mr.path, "desc", desc)
 	return nil
 }
 
@@ -413,6 +415,7 @@ func (mr *memRepo) blobDelete(d digest.Digest, locked bool) error {
 		}
 	}
 	mr.timeMod = time.Now()
+	mr.log.Debug("blob deleted", "repo", mr.path, "digest", d.String())
 	return nil
 }
 
@@ -510,6 +513,7 @@ func (mr *memRepo) gc() error {
 	mr.wg.Wait()
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
+	mr.log.Debug("starting GC", "repo", mr.path)
 	i, mod, err := repoGarbageCollect(mr, mr.conf, mr.index, true)
 	if err != nil {
 		return err
@@ -518,6 +522,7 @@ func (mr *memRepo) gc() error {
 		mr.index = i
 		mr.timeMod = time.Now()
 	}
+	mr.log.Debug("finished GC", "repo", mr.path)
 	return nil
 }
 
@@ -546,6 +551,7 @@ func (mru *memRepoUpload) Close() error {
 			mod: time.Now(),
 		},
 	}
+	mru.mr.log.Debug("blob created", "repo", mru.mr.path, "digest", mru.d.Digest().String())
 	return mru.mr.uploads.Delete(mru.sessionID)
 }
 


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

To facilitate easier debugging, this includes debug logs on changes to the store, when blobs are created or deleted, and when the index is modified.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Run a registry with debug logging and push/delete content:
```shell
go run ./cmd/olareg serve --port 5002 --store-type mem -v debug --gc-frequency 2m --gc-grace-period 5m --api-delete
regctl image copy localhost:5000/regclient/regctl localhost:5002/regclient/regctl
regctl image copy localhost:5000/regclient/regctl:alpine localhost:5002/regclient/regctl:alpine
regctl tag rm localhost:5002/regclient/regctl:alpine
# wait a few minutes to see output from GC
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Debug logs on store changes
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
