### PR TITLE
Fix: Logging of delete by tag and copying descriptors

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -54,7 +54,7 @@ func (s *Server) manifestDelete(repoStr, arg string) http.HandlerFunc {
 			_ = types.ErrRespJSON(w, types.ErrInfoManifestUnknown("tag or digest was not found in repository"))
 			return
 		}
-		// if referrers is enabled, get the manifest to check for a subject
+		// if referrers is enabled, remove entry from the referrers list
 		if *s.conf.API.Referrer.Enabled {
 			// wrap in a func to allow a return from errors without breaking the actual delete
 			err = func() error {
@@ -81,7 +81,7 @@ func (s *Server) manifestDelete(repoStr, arg string) http.HandlerFunc {
 				return nil
 			}()
 			if err != nil {
-				s.log.Info("failed to delete referrer", "repo", repoStr, "arg", arg, "err", err)
+				s.log.Info("failed to delete entry from referrers response", "repo", repoStr, "arg", arg, "err", err)
 			}
 		}
 		// delete the digest or tag

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -53,5 +53,11 @@ func (d Descriptor) Copy() Descriptor {
 		p := d.Platform.Copy()
 		d2.Platform = &p
 	}
+	if d.Annotations != nil {
+		d2.Annotations = make(map[string]string)
+		for k, v := range d.Annotations {
+			d2.Annotations[k] = v
+		}
+	}
 	return d2
 }

--- a/types/manifest.go
+++ b/types/manifest.go
@@ -103,22 +103,22 @@ func (i Index) Copy() Index {
 
 // GetDesc returns a descriptor for a tag or digest, including child descriptors.
 func (i Index) GetDesc(arg string) (Descriptor, error) {
-	var dRet Descriptor
+	var dZero Descriptor
 	if len(i.Manifests) == 0 {
-		return dRet, ErrNotFound
+		return dZero, ErrNotFound
 	}
 	if RefTagRE.MatchString(arg) {
 		// search for tag
 		for _, d := range i.Manifests {
 			if d.Annotations != nil && d.Annotations[AnnotRefName] == arg {
-				return d, nil
+				return d.Copy(), nil
 			}
 		}
 	} else {
 		// else, attempt to parse digest
 		dig, err := digest.Parse(arg)
 		if err != nil {
-			return dRet, err
+			return dZero, err
 		}
 		// return a matching descriptor, but stripped of any annotations to avoid mixing with tags
 		for _, d := range i.Manifests {
@@ -142,7 +142,7 @@ func (i Index) GetDesc(arg string) (Descriptor, error) {
 			}
 		}
 	}
-	return dRet, ErrNotFound
+	return dZero, ErrNotFound
 }
 
 // GetByAnnotation finds an entry with a matching annotation.


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Debug logging of a tag deletion does not show the tag annotation.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The descriptor was not copied, resulting in the deletion from the index overwriting the descriptor that was being logged. This fixes the `Index.GetDesc` call to always return a copy, and it fixes the copy to clone the annotations. This also improves the testing around GC.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
go run ./cmd/olareg serve --port 5002 --store-type mem -v debug --gc-frequency 2m --gc-grace-period 5m --api-delete --gc-untagged &
regctl image copy localhost:5000/regclient/regctl:alpine localhost:5002/regclient/regctl:alpine
regctl tag rm localhost:5002/regclient/regctl:alpine
# view the logs of the deleted descriptor
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Logging of delete by tag and copying descriptors
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
