### PR TITLE
Fix dockerfile linter warnings

### DIFF
--- a/build/Dockerfile.olareg
+++ b/build/Dockerfile.olareg
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
 ARG GO_VER=1.22.5-alpine@sha256:8c9183f715b0b4eca05b8b3dbf59766aaedb41ec07477b132ee2891ac0110a07
 
-FROM ${REGISTRY}/library/golang:${GO_VER} as golang
+FROM ${REGISTRY}/library/golang:${GO_VER} AS golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -12,7 +12,7 @@ RUN adduser -D appuser \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
-FROM golang as build
+FROM golang AS build
 COPY go.mod go.sum /src/
 RUN go mod download
 COPY . /src/
@@ -20,7 +20,7 @@ RUN make bin/olareg
 USER appuser
 CMD [ "bin/olareg" ]
 
-FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
+FROM ${REGISTRY}/library/alpine:${ALPINE_VER} AS release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=appuser /home/appuser /home/appuser
@@ -46,7 +46,7 @@ LABEL maintainer="" \
       org.opencontainers.image.title="olareg" \
       org.opencontainers.image.description="olareg is a minimal registry based on the OCI Layout"
 
-FROM scratch as release-scratch
+FROM scratch AS release-scratch
 COPY --from=build /tmp /
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/build/Dockerfile.olareg.buildkit
+++ b/build/Dockerfile.olareg.buildkit
@@ -4,7 +4,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
 ARG GO_VER=1.22.5-alpine@sha256:8c9183f715b0b4eca05b8b3dbf59766aaedb41ec07477b132ee2891ac0110a07
 
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as golang
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} AS golang
 RUN apk add --no-cache \
       ca-certificates \
       git \
@@ -15,7 +15,7 @@ RUN addgroup -g 1000 appuser \
  && chown -R appuser /home/appuser
 WORKDIR /src
 
-FROM --platform=$BUILDPLATFORM golang as build
+FROM --platform=$BUILDPLATFORM golang AS build
 COPY go.mod go.sum /src/
 ARG TARGETOS
 ARG TARGETARCH
@@ -31,10 +31,10 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
 USER appuser
 CMD [ "bin/olareg" ]
 
-FROM scratch as artifact
+FROM scratch AS artifact
 COPY --from=build /src/bin/olareg /olareg
 
-FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
+FROM ${REGISTRY}/library/alpine:${ALPINE_VER} AS release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=1000:1000 /home/appuser/ /home/appuser/
@@ -60,7 +60,7 @@ LABEL maintainer="" \
       org.opencontainers.image.title="olareg" \
       org.opencontainers.image.description="olareg is a minimal registry based on the OCI Layout"
 
-FROM scratch as release-scratch
+FROM scratch AS release-scratch
 COPY --from=build /tmp /
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The Dockerfile linter is now warning of the change in case between the `FROM` and `AS` parameters.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This fixing the Dockerfile linter warnings.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make docker
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Fix Dockerfile linter warnings.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
