### PR TITLE
Add support for changing the digest algorithm

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,23 +59,23 @@ type ConfigGC struct {
 }
 
 type ConfigAPI struct {
-	PushEnabled   *bool
-	DeleteEnabled *bool
+	PushEnabled   *bool // enable push to repository, enabled by default
+	DeleteEnabled *bool // enable deletion, disabled by default
 	Manifest      ConfigAPIManifest
 	Blob          ConfigAPIBlob
 	Referrer      ConfigAPIReferrer
 }
 
 type ConfigAPIManifest struct {
-	Limit int64
+	Limit int64 // max size of a manifest, default is 8MB (manifestLimitDefault)
 }
 
 type ConfigAPIBlob struct {
-	DeleteEnabled *bool
+	DeleteEnabled *bool // enable blob deletion, disabled by default, ConfigAPI.DeleteEnabled must also be true
 }
 
 type ConfigAPIReferrer struct {
-	Enabled         *bool
+	Enabled         *bool         // enable referrer API, enabled by default
 	PageCacheExpire time.Duration // time to save pages for a paged response
 	PageCacheLimit  int           // max number of paged responses to keep in memory
 	Limit           int64         // max size of a referrers response (OCI recommends 4MiB)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -79,7 +79,7 @@ type Repo interface {
 	gc() error
 }
 
-type BlobOpt func(*blobConfig)
+type BlobOpt func(*blobConfig) error
 
 type blobConfig struct {
 	algo   digest.Algorithm
@@ -87,15 +87,23 @@ type blobConfig struct {
 }
 
 func BlobWithAlgorithm(a digest.Algorithm) BlobOpt {
-	return func(bc *blobConfig) {
+	return func(bc *blobConfig) error {
+		if !a.Available() {
+			return fmt.Errorf("digest algorithm is unavailable: %s", string(a))
+		}
 		bc.algo = a
+		return nil
 	}
 }
 
 func BlobWithDigest(d digest.Digest) BlobOpt {
-	return func(bc *blobConfig) {
+	return func(bc *blobConfig) error {
+		if err := d.Validate(); err != nil {
+			return fmt.Errorf("invalid digest: %s: %w", d.String(), err)
+		}
 		bc.expect = d
 		bc.algo = d.Algorithm()
+		return nil
 	}
 }
 

--- a/manifest.go
+++ b/manifest.go
@@ -227,6 +227,17 @@ func (s *Server) manifestPut(repoStr, arg string) http.HandlerFunc {
 			_ = types.ErrRespJSON(w, types.ErrInfoManifestInvalid(fmt.Sprintf("manifest too large, limited to %d bytes", s.conf.API.Manifest.Limit)))
 			return
 		}
+		// parse params
+		// TODO(bmitch): the digest field is EXPERIMENTAL and needs to be adopted by OCI
+		if dStr := r.URL.Query().Get("digest"); dStr != "" {
+			dExpect, err = digest.Parse(dStr)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = types.ErrRespJSON(w, types.ErrInfoDigestInvalid("digest invalid"))
+				s.log.Debug("failed to parse digest", "repo", repoStr, "digest", dStr, "err", err)
+				return
+			}
+		}
 		// parse arg
 		if types.RefTagRE.MatchString(arg) {
 			tag = arg


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds support for changing the digest algorithm on blobs and manifests. It validates digests to prevent panics from go-digest.

Note: this includes experimental parameters on the API that have not yet been approved by OCI.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Push content with other digest algorithms.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Improve support for changing the digest algorithm and validate the digest to prevent panics.
- Experimental: add fields to manifest put and blob create to facilitate changing the digest algorithm.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
