### PR TITLE
Allow changing the digest algorithm on blob push

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -485,6 +485,13 @@ func (s *Server) blobUploadPut(repoStr, sessionID string) http.HandlerFunc {
 			s.log.Error("invalid or missing digest", "err", err, "repo", repoStr, "sessionID", sessionID, "digest", r.URL.Query().Get("digest"))
 			return
 		}
+		if bc.Size() == 0 && d.Algorithm() != bc.Digest().Algorithm() {
+			err = bc.ChangeAlgorithm(d.Algorithm())
+			if err != nil {
+				// non-fatal error, there's a second chance to handle this with bc.Verify
+				s.log.Error("failed to change digest algorithm", "err", err, "repo", repoStr, "sessionID", sessionID, "digest", d.String())
+			}
+		}
 		// check state
 		stateStr := r.URL.Query().Get("state")
 		stateIn := blobUploadState{}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -119,6 +119,8 @@ type BlobCreator interface {
 	Digest() digest.Digest
 	// Verify ensures a digest matches the content.
 	Verify(digest.Digest) error
+	// ChangeAlgorithm modifies the digest algorithm. This may only be rejected after the first write.
+	ChangeAlgorithm(digest.Algorithm) error
 }
 
 // blobMeta includes metadata available for blobs.


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Allow changing the digest algorithm on blob push.
This handles scenarios where clients either do a POST/PUT, or POST/PATCH/PUT. The former will adjust the digest algorithm before reading data, while the latter will result in rereading the blob.

This also removed the mem buffer truncate allowing the Verify to run after the Close. Buffer content will be eligible for Go GC after all references to the BlobCreator are gone.


<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Push content with a sha512 digest.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feature: Allow changing the digest algorithm on blob push.

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
