### PR TITLE
Chore: Upgrade staticcheck for Go 1.23 support and fix lint warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifneq "$(SYFT_CMD_VER)" "$(SYFT_VERSION)"
 		-u "$(shell id -u):$(shell id -g)" \
 		$(SYFT_CONTAINER)
 endif
-STATICCHECK_VER?=v0.4.7
+STATICCHECK_VER?=v0.5.0
 
 .PHONY: .FORCE
 .FORCE:

--- a/manifest.go
+++ b/manifest.go
@@ -69,7 +69,7 @@ func (s *Server) manifestDelete(repoStr, arg string) http.HandlerFunc {
 				}
 				subject, refDesc, err := types.ManifestReferrerDescriptor(raw, desc)
 				if err != nil {
-					if errors.Is(types.ErrNotFound, err) {
+					if errors.Is(err, types.ErrNotFound) {
 						return nil
 					}
 					return err

--- a/referrer.go
+++ b/referrer.go
@@ -335,7 +335,7 @@ func (s *Server) referrerDelete(repo store.Repo, subject digest.Digest, desc typ
 	// search for matching referrer descriptor
 	dOld, err := index.GetByAnnotation(types.AnnotReferrerSubject, subject.String())
 	if err != nil {
-		if errors.Is(types.ErrNotFound, err) {
+		if errors.Is(err, types.ErrNotFound) {
 			return nil
 		}
 		return err


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This upgrades staticcheck to support building with Go 1.23.0 and fixes the resulting linter warnings.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Upgrade staticcheck for Go 1.23 support and fix lint warnings.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
