### PR TITLE
Fix: Remove set-output from GHA

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,14 +100,8 @@ jobs:
         if [ -f "release.md" ] && grep -q "Release $VERSION" release.md; then
           VALID_RELEASE=true
         fi
-        RELEASE_NOTES=$(cat release.md || echo release notes unavailable)
-        # escape % and linefeeds
-        RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
-        RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-        RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-        echo ::set-output name=version::${VERSION}
-        echo ::set-output name=valid::${VALID_RELEASE}
-        echo ::set-output name=release_notes::${RELEASE_NOTES}
+        echo "valid=${VALID_RELEASE}" >>$GITHUB_OUTPUT
+        echo "version=${VERSION}" >>$GITHUB_OUTPUT
 
     - name: Create release
       if: steps.release_details.outputs.valid == 'true' && matrix.gover == env.RELEASE_GO_VER
@@ -117,7 +111,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ steps.release_details.outputs.version }}
-        body: ${{ steps.release_details.outputs.release_notes }}
+        body_path: release.md
         draft: false
         prerelease: false
         files: ./artifacts/*


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This removes the deprecated "set-output" method to store output from a step. It also passes `release.md` directly into `softprops/action-gh-release`.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

GHA should no longer have warnings.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Remove set-output from GHA.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
