### PR TITLE
Feat: Adding static basic auth

### DIFF
--- a/cmd/olareg/serve.go
+++ b/cmd/olareg/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -29,6 +30,8 @@ type serveOpts struct {
 	apiBlobDel       bool
 	apiReferrer      bool
 	apiRateLimit     int
+	authStaticLogin  []string
+	authStaticAnon   bool
 	gcFreq           time.Duration
 	gcGracePeriod    time.Duration
 	gcUntagged       bool
@@ -75,6 +78,10 @@ olareg serve --tls-cert host.pem --tls-key host.key --port 443
 	newCmd.Flags().BoolVar(&opts.apiBlobDel, "api-blob-delete", false, "enable blob delete API")
 	newCmd.Flags().BoolVar(&opts.apiReferrer, "api-referrer", true, "enable referrer API")
 	newCmd.Flags().IntVar(&opts.apiRateLimit, "rate-limit", 0, "limit requests per second per source IP")
+	newCmd.Flags().StringArrayVar(&opts.authStaticLogin, "auth-static-login", nil, "static auth: login (user:pass) in plain text (insecure)")
+	_ = newCmd.Flags().MarkHidden("auth-static-login") // unsupported option
+	newCmd.Flags().BoolVar(&opts.authStaticAnon, "auth-static-anon", false, "static auth: allow anonymous read access")
+	_ = newCmd.Flags().MarkHidden("auth-static-anon") // unsupported option
 	newCmd.Flags().DurationVar(&opts.gcFreq, "gc-frequency", time.Minute*15, "garbage collection frequency")
 	newCmd.Flags().DurationVar(&opts.gcGracePeriod, "gc-grace-period", time.Hour, "garbage collection grace period")
 	newCmd.Flags().BoolVar(&opts.gcUntagged, "gc-untagged", false, "garbage collect untagged manifests")
@@ -117,6 +124,16 @@ func (opts *serveOpts) run(cmd *cobra.Command, args []string) error {
 			RateLimit:     opts.apiRateLimit,
 			Warnings:      opts.warnings,
 		},
+	}
+	if len(opts.authStaticLogin) > 0 {
+		logins := map[string]string{}
+		for _, userPass := range opts.authStaticLogin {
+			userPassSplit := strings.SplitN(userPass, ":", 2)
+			if len(userPassSplit) == 2 {
+				logins[userPassSplit[0]] = userPassSplit[1]
+			}
+		}
+		conf.Auth.Handler = config.NewAuthBasicStatic(logins, opts.authStaticAnon)
 	}
 	s := olareg.New(conf)
 	// include signal handler to gracefully shutdown

--- a/config/auth.go
+++ b/config/auth.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type AuthAccess int
+
+const (
+	AuthRead AuthAccess = iota
+	AuthWrite
+	AuthDelete
+	AuthUnknown
+)
+
+// AuthHandler creates a new [http.Handler] that checks a request for the needed access.
+// It may refuse the request with a 401 status, www-authenticate header, and then return.
+// It may allow the request by calling the next handler without modifying the request or response writer.
+type AuthHandler func(repo string, access AuthAccess, next http.Handler) http.Handler
+
+// NewAuthBasicStatic uses a list of static plain text logins to control access to the registry.
+func NewAuthBasicStatic(logins map[string]string, allowAnonymousRead bool) AuthHandler {
+	ab := authBasic{
+		allowAnonymousRead: allowAnonymousRead,
+		checkPasswd: func(user, passwd string) bool {
+			if p, ok := logins[user]; ok && p == passwd {
+				return true
+			}
+			return false
+		},
+		checkAccess: func(user, repo string, access AuthAccess) bool { return true },
+		realm:       "olareg registry",
+	}
+	return ab.Handle
+}
+
+type authBasic struct {
+	allowAnonymousRead bool
+	checkPasswd        func(user, passwd string) bool
+	checkAccess        func(user, repo string, access AuthAccess) bool
+	realm              string
+}
+
+func (ab *authBasic) Handle(repo string, access AuthAccess, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// extract the user and verify access
+		user, passwd, ok := r.BasicAuth()
+		if (!ab.allowAnonymousRead || access != AuthRead) &&
+			(!ok ||
+				ab.checkPasswd == nil || !ab.checkPasswd(user, passwd) ||
+				ab.checkAccess == nil || !ab.checkAccess(user, repo, access)) {
+			err := unauthorized(w, "Basic", ab.realm, "", "", "")
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			return
+		}
+
+		if next != nil {
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+func unauthorized(w http.ResponseWriter, authType, realm, service, scope, errMsg string) error {
+	if authType == "" || realm == "" {
+		return fmt.Errorf("authType and realm are required")
+	}
+	h := fmt.Sprintf("%s realm=%q", authType, realm)
+	if service != "" {
+		h = fmt.Sprintf("%s,service=%q", h, service)
+	}
+	if scope != "" {
+		h = fmt.Sprintf("%s,scope=%q", h, scope)
+	}
+	if errMsg != "" {
+		h = fmt.Sprintf("%s,error=%q", h, errMsg)
+	}
+	w.Header().Add("WWW-Authenticate", h)
+	w.WriteHeader(http.StatusUnauthorized)
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -30,8 +31,8 @@ type Config struct {
 	Storage ConfigStorage
 	API     ConfigAPI
 	Log     *slog.Logger
+	Auth    ConfigAuth
 	// TODO: proxy settings, pull only, or push+pull cache
-	// TODO: auth options (basic, bearer)
 }
 
 type ConfigHTTP struct {
@@ -80,6 +81,11 @@ type ConfigAPIReferrer struct {
 	PageCacheExpire time.Duration // time to save pages for a paged response
 	PageCacheLimit  int           // max number of paged responses to keep in memory
 	Limit           int64         // max size of a referrers response (OCI recommends 4MiB)
+}
+
+type ConfigAuth struct {
+	Handler AuthHandler  // Handler is used to create a new [http.Handler] to authenticate request
+	Token   http.Handler // Token is a [http.Handler] that receives requests to the /token route
 }
 
 func (c *Config) SetDefaults() {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This is a first pass at auth with a future iteration that will use a config file, hashed passwords, support for groups, and access policies per repository. For now it is only a static and clear text user/password list that is supported using basic auth.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
olareg serve --auth-static-anon --auth-static-login testuser:testpass --auth-static-login anotheruser:anotherpass
```

Note that these flags are intentionally hidden and unsupported. The intended use case is embedded in a Go test where static credentials are acceptable.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add static basic auth.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
