### PR TITLE
Fix: Handle auth on disabled methods

### DIFF
--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -61,12 +61,13 @@ func TestAuthBasicFile(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	tt := []struct {
-		name       string
-		file       string
-		repo       string
-		access     AuthAccess
-		user, pass string
-		status     int
+		name        string
+		file        string
+		repo        string
+		access      AuthAccess
+		user, pass  string
+		emptyHeader bool
+		status      int
 	}{
 		{
 			name:   "invalid file",
@@ -105,6 +106,30 @@ func TestAuthBasicFile(t *testing.T) {
 			pass:   "password2",
 			access: AuthRead,
 			status: http.StatusOK,
+		},
+		{
+			name:   "any bob",
+			file:   "./testdata/auth_good.yaml",
+			repo:   "any/project-a",
+			user:   "bob",
+			pass:   "password2",
+			access: AuthWrite,
+			status: http.StatusOK,
+		},
+		{
+			name:   "public",
+			file:   "./testdata/auth_good.yaml",
+			access: AuthRead,
+			repo:   "public/project-a",
+			status: http.StatusOK,
+		},
+		{
+			name:        "public empty header",
+			file:        "./testdata/auth_good.yaml",
+			access:      AuthRead,
+			repo:        "public/project-a",
+			emptyHeader: true,
+			status:      http.StatusOK,
 		},
 	}
 	for _, tc := range tt {
@@ -206,12 +231,13 @@ func TestTokenOpaque(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	tt := []struct {
-		name       string
-		file       string
-		repo       string
-		access     AuthAccess
-		user, pass string
-		status     int
+		name        string
+		file        string
+		repo        string
+		access      AuthAccess
+		user, pass  string
+		emptyHeader bool
+		status      int
 	}{
 		{
 			name:   "invalid file",
@@ -250,6 +276,30 @@ func TestTokenOpaque(t *testing.T) {
 			pass:   "password2",
 			access: AuthRead,
 			status: http.StatusOK,
+		},
+		{
+			name:   "any bob",
+			file:   "./testdata/auth_good.yaml",
+			repo:   "any/project-a",
+			user:   "bob",
+			pass:   "password2",
+			access: AuthWrite,
+			status: http.StatusOK,
+		},
+		{
+			name:   "public",
+			file:   "./testdata/auth_good.yaml",
+			access: AuthRead,
+			repo:   "public/project-a",
+			status: http.StatusOK,
+		},
+		{
+			name:        "public empty header",
+			file:        "./testdata/auth_good.yaml",
+			access:      AuthRead,
+			repo:        "public/project-a",
+			emptyHeader: true,
+			status:      http.StatusOK,
 		},
 	}
 	for _, tc := range tt {

--- a/config/testdata/auth_good.yaml
+++ b/config/testdata/auth_good.yaml
@@ -25,3 +25,6 @@ acls:
   - repo: "public/*"
     anonymous: true
     access: ["read"]
+  - repo: "any/*"
+    members: ["all"]
+    access: ["*"]

--- a/types/errors.go
+++ b/types/errors.go
@@ -3,7 +3,7 @@ package types
 import (
 	"encoding/json"
 	"errors"
-	"io"
+	"net/http"
 )
 
 var (
@@ -25,10 +25,11 @@ type ErrorResp struct {
 }
 
 // ErrRespJSON encodes a list of errors to json and outputs them to the writer.
-func ErrRespJSON(w io.Writer, errList ...ErrorInfo) error {
+func ErrRespJSON(w http.ResponseWriter, errList ...ErrorInfo) error {
 	resp := ErrorResp{
 		Errors: errList,
 	}
+	w.Header().Add("content-type", "application/json")
 	return json.NewEncoder(w).Encode(resp)
 }
 


### PR DESCRIPTION

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Multiple changes to improve OCI conformance test results and to better handle disabled methods with auth. This will still verify auth before indicating that a method is not supported. Previously a disabled method would trigger an auth failure for not passing the repo and access request to auth.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```

Or run the OCI conformance test with auth enabled.

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Handle auth on disabled methods.
- Feat: Add a json error message on auth failures.
- Feat: Add a wildcard access that will match on unknown methods.
- Feat: Support user/pass being explicitly set to empty strings as an anonymous login.
- Fix: Add content-type header to JSON error messages.

<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

External documentation on the auth yaml syntax still needs to be added to the website.
<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
