### PR TITLE
Feat: Permissive handling of manifest media type accept header

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -138,6 +138,7 @@ func (s *Server) manifestGet(repoStr, arg string) http.HandlerFunc {
 				err = json.NewDecoder(rdr).Decode(&i)
 				if err != nil {
 					w.WriteHeader(http.StatusInternalServerError)
+					s.log.Info("failed to parse index searching for a media type match", "err", err, "repo", repoStr, "arg", arg)
 					return
 				}
 				found := false

--- a/types/mediatype.go
+++ b/types/mediatype.go
@@ -44,14 +44,34 @@ func MediaTypeBase(orig string) string {
 	return strings.TrimSpace(strings.ToLower(base))
 }
 
-// MediaTypeAccepts returns true when the descriptor is listed in the accept list.
+// MediaTypeAccepts returns true when the descriptor is listed in the accept list or accept list is empty.
 func MediaTypeAccepts(mt string, accepts []string) bool {
+	if len(accepts) == 0 {
+		return true
+	}
 	for _, a := range accepts {
 		for entry := range strings.SplitSeq(a, ",") {
-			if MediaTypeBase(entry) == mt {
+			if MediaTypeMatch(mt, MediaTypeBase(entry)) {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+// MediaTypeMatch does a wildcard compare of two base media types
+func MediaTypeMatch(mt, accept string) bool {
+	if mt == accept {
+		return true
+	}
+	// handle wildcards
+	mtSplit := strings.Split(mt, "/")
+	acceptSplit := strings.Split(accept, "/")
+	if len(mtSplit) != 2 || len(acceptSplit) != 2 {
+		return false
+	}
+	if acceptSplit[1] == "*" && (acceptSplit[0] == "*" || acceptSplit[0] == mtSplit[0]) {
+		return true
 	}
 	return false
 }

--- a/types/mediatype_test.go
+++ b/types/mediatype_test.go
@@ -40,13 +40,19 @@ func TestMediaTypeAccepts(t *testing.T) {
 		expect  bool
 	}{
 		{
+			name:    "Empty",
+			mt:      MediaTypeOCI1ManifestList,
+			accepts: []string{},
+			expect:  true,
+		},
+		{
 			name:    "Single",
 			mt:      MediaTypeOCI1ManifestList,
 			accepts: []string{MediaTypeOCI1ManifestList},
 			expect:  true,
 		},
 		{
-			name:    "Missing",
+			name:    "Mismatch",
 			mt:      MediaTypeOCI1Manifest,
 			accepts: []string{MediaTypeOCI1ManifestList},
 			expect:  false,
@@ -62,6 +68,30 @@ func TestMediaTypeAccepts(t *testing.T) {
 			mt:      MediaTypeOCI1ManifestList,
 			accepts: []string{"application/vnd.oci.image.manifest.v1+json; charset=utf-8, application/vnd.oci.image.index.v1+json; charset=utf-8"},
 			expect:  true,
+		},
+		{
+			name:    "Wildcard",
+			mt:      MediaTypeOCI1ManifestList,
+			accepts: []string{"*/*"},
+			expect:  true,
+		},
+		{
+			name:    "Partial wildcard",
+			mt:      MediaTypeOCI1ManifestList,
+			accepts: []string{"application/*"},
+			expect:  true,
+		},
+		{
+			name:    "Invalid wildcard",
+			mt:      MediaTypeOCI1ManifestList,
+			accepts: []string{"*/vnd.oci.image.index.v1+json"},
+			expect:  false,
+		},
+		{
+			name:    "Mismatch wildcard",
+			mt:      MediaTypeOCI1ManifestList,
+			accepts: []string{"text/*"},
+			expect:  false,
 		},
 	}
 	for _, tc := range tt {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Allow a missing accept header, or an accept header containing wildcards following RFC9110. This better aligns with the upstream RFCs and the behavior of the distribution project even though the OCI spec currently suggests servers should be more strict and fallback to Docker schema v1 media types.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
curl http://localhost:5000/v2/$repo/manifests/$tag
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Permissive handling of manifest media type accept header.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the olareg.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
