### PR TITLE
Fix: Generate semver tags for released images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,14 +66,14 @@ jobs:
         if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
           MINOR="${VERSION%.*}"
           MAJOR="${MINOR%.*}"
-          # TAGS_COPIES="${TAGS_COPIES},${HUB_IMAGE}:${MINOR}${EXT},${HUB_IMAGE}:${MAJOR}${EXT}"
-          TAGS_COPIES="${TAGS_COPIES},${GHCR_IMAGE}:${MINOR}${EXT},${GHCR_IMAGE}:${MAJOR}${EXT}"
+          TAG_COPIES="${GHCR_IMAGE}:${MINOR}${EXT},${GHCR_IMAGE}:${MAJOR}${EXT}"
+          # TAG_COPIES="${TAG_COPIES},${HUB_IMAGE}:${MINOR}${EXT},${HUB_IMAGE}:${MAJOR}${EXT}"
           if [ "${{ matrix.type }}" == "scratch" ]; then
-            # TAGS_COPIES="${TAGS_COPIES},${HUB_IMAGE}:latest"
-            TAGS_COPIES="${TAGS_COPIES},${GHCR_IMAGE}:latest"
+            TAG_COPIES="${TAG_COPIES},${GHCR_IMAGE}:latest"
+            # TAG_COPIES="${TAG_COPIES},${HUB_IMAGE}:latest"
           else
-            # TAGS_COPIES="${TAGS_COPIES},${HUB_IMAGE}:${{ matrix.type }}"
-            TAGS_COPIES="${TAGS_COPIES},${GHCR_IMAGE}:${{ matrix.type }}"
+            TAG_COPIES="${TAG_COPIES},${GHCR_IMAGE}:${{ matrix.type }}"
+            # TAG_COPIES="${TAG_COPIES},${HUB_IMAGE}:${{ matrix.type }}"
           fi
         fi
         VCS_SEC="$(git log -1 --format=%ct)"


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Fix the variable name used for generating the semver and latest image tags. This also reverses the order in case Docker Hub images are pushed in the future.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

This only runs on a stable release. Tags need to be manually checked after that.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Generate semver tags for released images.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the olareg.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
