### PR TITLE
Feat: Support SOURCE_DATE_EPOC for timestamps  in index.json

### DIFF
--- a/internal/reproducible/reproducible.go
+++ b/internal/reproducible/reproducible.go
@@ -1,0 +1,17 @@
+// Copyright the olareg contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package reproducible is used for reproducibility.
+// See <https://reproducible-builds.org/docs/> for more information of the issues being solved.
+package reproducible

--- a/internal/reproducible/time.go
+++ b/internal/reproducible/time.go
@@ -1,0 +1,53 @@
+// Copyright the olareg contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reproducible
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const EpocEnv = "SOURCE_DATE_EPOC"
+
+var (
+	timeProcOnce sync.Once
+	timeProcTime time.Time
+)
+
+// TimeNow returns the current time or SOURCE_DATE_EPOC if that is set.
+func TimeNow() time.Time {
+	timeProcOnce.Do(TimeProcEnv)
+	if !timeProcTime.IsZero() {
+		return timeProcTime
+	}
+	return time.Now().UTC()
+}
+
+// TimeProcEnv processes the time in the SOURCE_DATE_EPOC environment variable.
+// This is typically only run once by [TimeNow] but may be manually run if the environment is modified while the application is running.
+func TimeProcEnv() {
+	timeProcTime = time.Time{}
+	sec := os.Getenv(EpocEnv)
+	if sec == "" {
+		return
+	}
+	secI, err := strconv.ParseInt(sec, 10, 64)
+	if err != nil {
+		return
+	}
+	timeProcTime = time.Unix(secI, 0).UTC()
+}

--- a/internal/reproducible/time_test.go
+++ b/internal/reproducible/time_test.go
@@ -1,0 +1,42 @@
+// Copyright the olareg contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reproducible
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestTimeNow(t *testing.T) {
+	t.Run("NoEnv", func(t *testing.T) {
+		t.Setenv(EpocEnv, "")
+		TimeProcEnv()
+		curTimeNow := TimeNow()
+		if curTimeNow.After(time.Now()) {
+			t.Error("timeNow reported a time after OS time now")
+		}
+	})
+	t.Run("WithEnv", func(t *testing.T) {
+		timePrev := time.Now().Add(-1 * time.Hour).Round(time.Second)
+		timeSec := fmt.Sprintf("%d", timePrev.Unix())
+		t.Setenv(EpocEnv, timeSec)
+		TimeProcEnv()
+		curTimeNow := TimeNow()
+		if !curTimeNow.Equal(timePrev) {
+			t.Errorf("timeNow did not use the epoc, expected %d, received %d", timePrev.Unix(), curTimeNow.Unix())
+		}
+	})
+}

--- a/types/manifest.go
+++ b/types/manifest.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	digest "github.com/sudo-bmitch/oci-digest"
+
+	"github.com/olareg/olareg/internal/reproducible"
 )
 
 // Index references manifests for various platforms.
@@ -184,7 +186,7 @@ func (i *Index) AddDesc(d Descriptor, opts ...IndexOpt) {
 		d.Annotations = map[string]string{}
 	}
 	// Set creation time on descriptor
-	d.Annotations[AnnotCreated] = time.Now().UTC().Format(time.RFC3339)
+	d.Annotations[AnnotCreated] = reproducible.TimeNow().Format(time.RFC3339)
 	// extract tag and referrer details if set
 	tag := d.Annotations[AnnotRefName]
 	referrer := d.Annotations[AnnotReferrerSubject]

--- a/types/manifest_test.go
+++ b/types/manifest_test.go
@@ -16,10 +16,13 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	digest "github.com/sudo-bmitch/oci-digest"
+
+	"github.com/olareg/olareg/internal/reproducible"
 )
 
 func TestIndex(t *testing.T) {
@@ -508,7 +511,10 @@ func TestIndex(t *testing.T) {
 }
 
 func TestAddDesc(t *testing.T) {
-	t.Parallel()
+	// set a persistent time that will be in all new descriptors
+	t.Setenv(reproducible.EpocEnv, fmt.Sprintf("%d", time.Now().UTC().Unix()))
+	reproducible.TimeProcEnv()
+	timestamp := reproducible.TimeNow().Format(time.RFC3339)
 	// setup some sample index structs, empty, one entry, three entries, tags, annotations, children
 	tagA, tagB, tagC, tagD, tagIndex := "A", "B", "C", "D", "index"
 	digA, err := digest.FromString("A")
@@ -523,9 +529,12 @@ func TestAddDesc(t *testing.T) {
 		MediaType: MediaTypeOCI1Manifest,
 		Digest:    digA,
 		Size:      1,
-		Annotations: map[string]string{
-			AnnotCreated: time.Now().UTC().Format(time.RFC3339),
-		},
+	}
+	descATime := Descriptor{
+		MediaType:   MediaTypeOCI1Manifest,
+		Digest:      digA,
+		Size:        1,
+		Annotations: map[string]string{AnnotCreated: timestamp},
 	}
 	descATag := Descriptor{
 		MediaType: MediaTypeOCI1Manifest,
@@ -533,7 +542,7 @@ func TestAddDesc(t *testing.T) {
 		Size:      1,
 		Annotations: map[string]string{
 			AnnotRefName: tagA,
-			AnnotCreated: time.Now().UTC().Format(time.RFC3339),
+			AnnotCreated: timestamp,
 		},
 	}
 	digB, err := digest.FromString("B")
@@ -545,13 +554,19 @@ func TestAddDesc(t *testing.T) {
 		Digest:    digB,
 		Size:      1,
 	}
+	descBTime := Descriptor{
+		MediaType:   MediaTypeOCI1Manifest,
+		Digest:      digB,
+		Size:        1,
+		Annotations: map[string]string{AnnotCreated: timestamp},
+	}
 	descBTag := Descriptor{
 		MediaType: MediaTypeOCI1Manifest,
 		Digest:    digB,
 		Size:      1,
 		Annotations: map[string]string{
 			AnnotRefName: tagB,
-			AnnotCreated: time.Now().UTC().Format(time.RFC3339),
+			AnnotCreated: timestamp,
 		},
 	}
 	digC, err := digest.FromString("C")
@@ -563,13 +578,19 @@ func TestAddDesc(t *testing.T) {
 		Digest:    digC,
 		Size:      1,
 	}
+	descCTime := Descriptor{
+		MediaType:   MediaTypeOCI1Manifest,
+		Digest:      digC,
+		Size:        1,
+		Annotations: map[string]string{AnnotCreated: timestamp},
+	}
 	descCTag := Descriptor{
 		MediaType: MediaTypeOCI1Manifest,
 		Digest:    digC,
 		Size:      1,
 		Annotations: map[string]string{
 			AnnotRefName: tagC,
-			AnnotCreated: time.Now().UTC().Format(time.RFC3339),
+			AnnotCreated: timestamp,
 		},
 	}
 	descCSubj := Descriptor{
@@ -586,6 +607,12 @@ func TestAddDesc(t *testing.T) {
 		MediaType: MediaTypeOCI1Manifest,
 		Digest:    digD,
 		Size:      1,
+	}
+	descDTime := Descriptor{
+		MediaType:   MediaTypeOCI1Manifest,
+		Digest:      digD,
+		Size:        1,
+		Annotations: map[string]string{AnnotCreated: timestamp},
 	}
 	// descDTag := Descriptor{
 	// 	MediaType:   MediaTypeOCI1Manifest,
@@ -612,34 +639,32 @@ func TestAddDesc(t *testing.T) {
 		MediaType:   MediaTypeOCI1ManifestList,
 		Digest:      digIndex,
 		Size:        5,
-		Annotations: map[string]string{AnnotRefName: tagIndex},
+		Annotations: map[string]string{AnnotRefName: tagIndex, AnnotCreated: timestamp},
 	}
 	_ = tagD
 	tt := []struct {
-		name         string
-		iIn          Index
-		dAdd         Descriptor
-		opts         []IndexOpt
-		iOut         Index
-		checkCreated bool
+		name string
+		iIn  Index
+		dAdd Descriptor
+		opts []IndexOpt
+		iOut Index
 	}{
 		{
 			name: "Zero Add A",
 			iIn:  Index{},
 			dAdd: descA,
 			iOut: Index{
-				Manifests: []Descriptor{descA},
+				Manifests: []Descriptor{descATime},
 			},
-			checkCreated: true,
 		},
 		{
 			name: "A Add A",
 			iIn: Index{
-				Manifests: []Descriptor{descA},
+				Manifests: []Descriptor{descATime},
 			},
 			dAdd: descA,
 			iOut: Index{
-				Manifests: []Descriptor{descA},
+				Manifests: []Descriptor{descATime},
 			},
 		},
 		{
@@ -655,54 +680,39 @@ func TestAddDesc(t *testing.T) {
 		{
 			name: "A Add B",
 			iIn: Index{
-				Manifests: []Descriptor{descA},
+				Manifests: []Descriptor{descATime},
 			},
 			dAdd: descB,
 			iOut: Index{
-				Manifests: []Descriptor{descA, descB},
+				Manifests: []Descriptor{descATime, descBTime},
 			},
-			checkCreated: true,
 		},
 		{
 			name: "ABC Add tag to B",
 			iIn: Index{
-				Manifests: []Descriptor{descA, {
-					MediaType: MediaTypeOCI1Manifest,
-					Digest:    digB,
-					Size:      1,
-				}, descC},
+				Manifests: []Descriptor{descATime, descB, descC},
 			},
 			dAdd: descBTag,
 			iOut: Index{
-				Manifests: []Descriptor{descA, descBTag, descC},
+				Manifests: []Descriptor{descATime, descBTag, descC},
 			},
 		},
 		{
 			name: "ABC children Add tag to child B",
 			iIn: Index{
-				Manifests: []Descriptor{descIndexTag},
-				childManifests: []Descriptor{descA, {
-					MediaType: MediaTypeOCI1Manifest,
-					Digest:    digB,
-					Size:      1,
-				}, descC},
+				Manifests:      []Descriptor{descIndexTag},
+				childManifests: []Descriptor{descA, descB, descC},
 			},
 			dAdd: descBTag,
 			iOut: Index{
 				Manifests:      []Descriptor{descIndexTag, descBTag},
 				childManifests: []Descriptor{descA, descC},
 			},
-			checkCreated: true,
 		},
 		{
-			name: "ABC tag Add replacement A tag",
+			name: "ABC tag replace A tag digest",
 			iIn: Index{
-				Manifests: []Descriptor{{
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagA},
-				}, descBTag, descCTag},
+				Manifests: []Descriptor{descATag, descBTag, descCTag},
 			},
 			dAdd: Descriptor{
 				MediaType:   MediaTypeOCI1Manifest,
@@ -711,14 +721,13 @@ func TestAddDesc(t *testing.T) {
 				Annotations: map[string]string{AnnotRefName: tagA},
 			},
 			iOut: Index{
-				Manifests: []Descriptor{descA, descBTag, descCTag, {
+				Manifests: []Descriptor{descATime, descBTag, descCTag, {
 					MediaType:   MediaTypeOCI1Manifest,
 					Digest:      digA2,
 					Size:        2,
-					Annotations: map[string]string{AnnotRefName: tagA},
+					Annotations: map[string]string{AnnotRefName: tagA, AnnotCreated: timestamp},
 				}},
 			},
-			checkCreated: true,
 		},
 		{
 			name: "ABC subject Add replacement subject to A",
@@ -736,41 +745,30 @@ func TestAddDesc(t *testing.T) {
 					MediaType:   MediaTypeOCI1Manifest,
 					Digest:      digD,
 					Size:        1,
-					Annotations: map[string]string{AnnotReferrerSubject: digA.String()},
+					Annotations: map[string]string{AnnotReferrerSubject: digA.String(), AnnotCreated: timestamp},
 				}},
 			},
-			checkCreated: true,
 		},
 		{
-			name: "ABCD Add IndexTag with Children",
+			name: "ABCD Add IndexTag with Children BCD",
 			iIn: Index{
-				Manifests: []Descriptor{descA, descB, descC, descD},
+				Manifests: []Descriptor{descATime, descBTime, descCTime, descDTime},
 			},
 			dAdd: descIndexTag,
 			opts: []IndexOpt{IndexWithChildren([]Descriptor{descB, descC, descD})},
 			iOut: Index{
-				Manifests:      []Descriptor{descA, descIndexTag},
+				Manifests:      []Descriptor{descATime, descIndexTag},
 				childManifests: []Descriptor{descB, descC, descD},
 			},
-			checkCreated: true,
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			ind := tc.iIn.Copy() // clone to avoid modifying a descriptor used in other tests
 			t.Parallel()
-			tc.iIn.AddDesc(tc.dAdd, tc.opts...)
-			if !testIndexEqual(tc.iIn, tc.iOut) {
-				t.Errorf("index mismatch, expected %v, received %v", tc.iOut, tc.iIn)
-			}
-			if tc.checkCreated {
-				last := len(tc.iIn.Manifests) - 1
-				if last < 0 {
-					t.Errorf("no last entry to check creation timestamp")
-				} else if tc.iIn.Manifests[last].Annotations == nil {
-					t.Errorf("annotations are not defined on last entry: %v", tc.iIn.Manifests[last])
-				} else if tc.iIn.Manifests[last].Annotations[AnnotCreated] == "" {
-					t.Errorf("creation timestamp was not set on last entry: %v", tc.iIn.Manifests[last])
-				}
+			ind.AddDesc(tc.dAdd, tc.opts...)
+			if !testIndexEqual(ind, tc.iOut) {
+				t.Errorf("index mismatch, expected %v, received %v", tc.iOut, ind)
 			}
 		})
 	}
@@ -1035,10 +1033,6 @@ func TestRmDesc(t *testing.T) {
 	}
 }
 
-// TODO: test AddDesc, tt with index, desc to add, result. test digests, tags, referrers, children
-
-// TODO: test RmDesc, tt with index, desc to remove, result. test digests, tags, referrers, children
-
 func testDescEqual(a, b Descriptor) bool {
 	if a.MediaType != b.MediaType ||
 		a.Size != b.Size ||
@@ -1046,7 +1040,7 @@ func testDescEqual(a, b Descriptor) bool {
 		a.ArtifactType != b.ArtifactType {
 		return false
 	}
-	// only compare well-known annotations, avoid failing for a changed timestamp or dropped unknown annotation
+	// only compare well-known annotations, don't error on dropped unknown annotation
 	aAnnotations := map[string]string{}
 	bAnnotations := map[string]string{}
 	if len(a.Annotations) > 0 {
@@ -1055,7 +1049,7 @@ func testDescEqual(a, b Descriptor) bool {
 	if len(b.Annotations) > 0 {
 		bAnnotations = b.Annotations
 	}
-	for _, key := range []string{AnnotRefName, AnnotReferrerSubject} {
+	for _, key := range []string{AnnotRefName, AnnotReferrerSubject, AnnotCreated} {
 		if aAnnotations[key] != bAnnotations[key] {
 			return false
 		}


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Support `SOURCE_DATE_EPOC` for timestamps  in `index.json`.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
SOURCE_DATE_EPOC=1784316593 olareg serve ...
```

Will run a server where all timestamps are set to 2026-07-17T19:29:53Z.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Support SOURCE_DATE_EPOC for timestamps  in index.json.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [ ] Documentation updates are included or not applicable (most documentation should be in the olareg.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
