### PR TITLE
Feat: Add tag history tracking

### DIFF
--- a/internal/store/dir.go
+++ b/internal/store/dir.go
@@ -56,7 +56,7 @@ type dirRepo struct {
 	name      string
 	path      string
 	exists    bool
-	index     types.Index
+	index     types.LayoutIndex
 	uploads   *cache.Cache[string, *dirRepoUpload]
 	log       *slog.Logger
 	conf      config.Config
@@ -277,8 +277,8 @@ func (d *dir) gc(cur, prev time.Time) error {
 	return nil
 }
 
-// IndexGet returns the current top level index for a repo.
-func (dr *dirRepo) IndexGet() (types.Index, error) {
+// IndexGet returns the current top level index.json for a repo.
+func (dr *dirRepo) IndexGet() (types.LayoutIndex, error) {
 	dr.mu.Lock()
 	defer dr.mu.Unlock()
 	err := dr.indexLoad(false, true)
@@ -290,7 +290,7 @@ func (dr *dirRepo) IndexGet() (types.Index, error) {
 }
 
 // IndexInsert adds a new entry to the index and writes the change to index.json.
-func (dr *dirRepo) IndexInsert(desc types.Descriptor, opts ...types.IndexOpt) error {
+func (dr *dirRepo) IndexInsert(desc types.Descriptor, opts ...types.LayoutIndexOpt) error {
 	if *dr.conf.Storage.ReadOnly {
 		return types.ErrReadOnly
 	}
@@ -568,11 +568,13 @@ func (dr *dirRepo) indexLoad(force, locked bool) error {
 	}
 	if dr.index.MediaType == "" && len(dr.index.Manifests) == 0 {
 		// default values for the index if the load fails (does not exist or unparsable)
-		dr.index = types.Index{
-			SchemaVersion: 2,
-			MediaType:     types.MediaTypeOCI1ManifestList,
-			Manifests:     []types.Descriptor{},
-			Annotations:   map[string]string{},
+		dr.index = types.LayoutIndex{
+			Index: types.Index{
+				SchemaVersion: 2,
+				MediaType:     types.MediaTypeOCI1ManifestList,
+				Manifests:     []types.Descriptor{},
+				Annotations:   map[string]string{},
+			},
 		}
 		if *dr.conf.API.Referrer.Enabled {
 			dr.index.Annotations[types.AnnotReferrerConvert] = "true"
@@ -595,7 +597,7 @@ func (dr *dirRepo) indexLoad(force, locked bool) error {
 		// file is unchanged from previous loaded version
 		return nil
 	}
-	parseIndex := types.Index{}
+	parseIndex := types.LayoutIndex{}
 	err = json.NewDecoder(fh).Decode(&parseIndex)
 	if err != nil {
 		return err

--- a/internal/store/mem.go
+++ b/internal/store/mem.go
@@ -50,7 +50,7 @@ type memRepo struct {
 	wg      sync.WaitGroup
 	wgBlock chan struct{}
 	timeMod time.Time
-	index   types.Index
+	index   types.LayoutIndex
 	blobs   map[digest.Digest]*memRepoBlob
 	uploads *cache.Cache[string, *memRepoUpload]
 	log     *slog.Logger
@@ -125,11 +125,13 @@ func (m *mem) RepoGet(ctx context.Context, repoStr string) (Repo, error) {
 	}
 	mr := &memRepo{
 		wgBlock: make(chan struct{}, 1),
-		index: types.Index{
-			SchemaVersion: 2,
-			MediaType:     types.MediaTypeOCI1ManifestList,
-			Manifests:     []types.Descriptor{},
-			Annotations:   map[string]string{},
+		index: types.LayoutIndex{
+			Index: types.Index{
+				SchemaVersion: 2,
+				MediaType:     types.MediaTypeOCI1ManifestList,
+				Manifests:     []types.Descriptor{},
+				Annotations:   map[string]string{},
+			},
 		},
 		blobs: map[digest.Digest]*memRepoBlob{},
 		log:   m.log,
@@ -254,7 +256,7 @@ func (m *mem) gc(cur, prev time.Time) error {
 }
 
 // IndexGet returns the current top level index for a repo.
-func (mr *memRepo) IndexGet() (types.Index, error) {
+func (mr *memRepo) IndexGet() (types.LayoutIndex, error) {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 	ic := mr.index.Copy()
@@ -262,7 +264,7 @@ func (mr *memRepo) IndexGet() (types.Index, error) {
 }
 
 // IndexInsert adds a new entry to the index and writes the change to index.json.
-func (mr *memRepo) IndexInsert(desc types.Descriptor, opts ...types.IndexOpt) error {
+func (mr *memRepo) IndexInsert(desc types.Descriptor, opts ...types.LayoutIndexOpt) error {
 	if *mr.conf.Storage.ReadOnly {
 		return types.ErrReadOnly
 	}
@@ -521,7 +523,7 @@ func (mr *memRepo) repoInit() error {
 		return err
 	}
 	defer fh.Close()
-	parseIndex := types.Index{}
+	parseIndex := types.LayoutIndex{}
 	err = json.NewDecoder(fh).Decode(&parseIndex)
 	if err != nil {
 		return err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -56,9 +56,9 @@ type Store interface {
 // Repo interface is used to access a CAS and the index managing known manifests.
 type Repo interface {
 	// IndexGet returns the current top level index for a repo.
-	IndexGet() (types.Index, error)
+	IndexGet() (types.LayoutIndex, error)
 	// IndexInsert adds a new entry to the index and writes the change to index.json.
-	IndexInsert(desc types.Descriptor, opts ...types.IndexOpt) error
+	IndexInsert(desc types.Descriptor, opts ...types.LayoutIndexOpt) error
 	// IndexRemove deletes an entry from the index and writes the change to index.json.
 	IndexRemove(desc types.Descriptor) error
 
@@ -157,9 +157,9 @@ func genSessionID() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(sb), nil
 }
 
-// indexIngest processes an index, adding child descriptors, and converting referrers if appropriate.
+// indexIngest processes an index.json file, adding child descriptors, and converting referrers if appropriate.
 // return is true when index has been modified.
-func indexIngest(repo Repo, index *types.Index, conf config.Config, locked bool) (bool, error) {
+func indexIngest(repo Repo, index *types.LayoutIndex, conf config.Config, locked bool) (bool, error) {
 	mod := false
 	// error if referrer API not enabled and annotation indicates this is already converted, this repo should not writable
 	if !*conf.API.Referrer.Enabled && index.Annotations != nil && index.Annotations[types.AnnotReferrerConvert] == "true" {
@@ -398,7 +398,7 @@ func referrerListDedup(rl []types.Descriptor) []types.Descriptor {
 // repoGarbageCollect runs a GC against the repo.
 // The repo should be locked before calling this.
 // Changes to the index will be returned and should be saved to the store.
-func repoGarbageCollect(repo Repo, conf config.Config, index types.Index, locked bool) (types.Index, bool, error) {
+func repoGarbageCollect(repo Repo, conf config.Config, index types.LayoutIndex, locked bool) (types.LayoutIndex, bool, error) {
 	var cutoff time.Time
 	if conf.Storage.GC.GracePeriod >= 0 {
 		cutoff = time.Now().Add(conf.Storage.GC.GracePeriod * -1)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1581,10 +1581,10 @@ func TestGarbageCollect(t *testing.T) {
 				}
 			}
 			for i, desc := range descList {
-				opts := []types.IndexOpt{}
+				opts := []types.LayoutIndexOpt{}
 				if i == len(descList)-1 {
 					// append all children on last entry
-					opts = append(opts, types.IndexWithChildren(childList))
+					opts = append(opts, types.LayoutWithChildren(childList))
 				}
 				err = repo.IndexInsert(desc, opts...)
 				if err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -202,7 +202,7 @@ func (s *Server) manifestPut(repoStr, arg string) http.HandlerFunc {
 			return
 		}
 		var dExpect digest.Digest
-		addOpts := []types.IndexOpt{}
+		addOpts := []types.LayoutIndexOpt{}
 		repo, err := s.store.RepoGet(r.Context(), repoStr)
 		if err != nil {
 			if errors.Is(err, types.ErrRepoNotAllowed) {
@@ -349,7 +349,7 @@ func (s *Server) manifestPut(repoStr, arg string) http.HandlerFunc {
 				s.log.Debug("failed to parse image manifest", "repo", repoStr, "arg", arg, "mediaType", mt, "err", err)
 				return
 			}
-			addOpts = append(addOpts, types.IndexWithChildren(m.Manifests))
+			addOpts = append(addOpts, types.LayoutWithChildren(m.Manifests))
 			// validate manifests exist
 			eList := s.manifestVerifyIndex(repo, m)
 			if eList != nil {

--- a/referrer.go
+++ b/referrer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 
 	digest "github.com/sudo-bmitch/oci-digest"
@@ -304,8 +305,14 @@ func (s *Server) referrerAdd(repo store.Repo, subject digest.Digest, desc types.
 			}
 		}()
 	}
-	// add descriptor to index and push into blob store
-	refResp.AddDesc(desc)
+	if mi := slices.IndexFunc(refResp.Manifests, func(cur types.Descriptor) bool { return desc.Digest.Equal(cur.Digest) }); mi >= 0 {
+		// replace existing response with this digest
+		refResp.Manifests[mi] = desc
+	} else {
+		// add descriptor to index
+		refResp.Manifests = append(refResp.Manifests, desc)
+	}
+	// push the updated response to the blob store
 	iRaw, err := json.Marshal(refResp)
 	if err != nil {
 		return err
@@ -339,7 +346,7 @@ func (s *Server) referrerAdd(repo store.Repo, subject digest.Digest, desc types.
 		},
 	}
 	// adding the new response also deletes the previous response
-	err = repo.IndexInsert(dNew, types.IndexWithChildren(refResp.Manifests))
+	err = repo.IndexInsert(dNew, types.LayoutWithChildren(refResp.Manifests))
 	if err != nil {
 		return err
 	}
@@ -377,7 +384,7 @@ func (s *Server) referrerDelete(repo store.Repo, subject digest.Digest, desc typ
 		return err
 	}
 	// remove descriptor from response
-	refResp.RmDesc(desc)
+	refResp.Manifests = slices.DeleteFunc(refResp.Manifests, func(cur types.Descriptor) bool { return desc.Digest.Equal(cur.Digest) })
 	// push response back to blob store with a new digest
 	refRespRaw, err = json.Marshal(refResp)
 	if err != nil {
@@ -412,7 +419,7 @@ func (s *Server) referrerDelete(repo store.Repo, subject digest.Digest, desc typ
 		},
 	}
 	// adding the new response also deletes the previous response
-	err = repo.IndexInsert(dNew, types.IndexWithChildren(refResp.Manifests))
+	err = repo.IndexInsert(dNew, types.LayoutWithChildren(refResp.Manifests))
 	if err != nil {
 		return err
 	}

--- a/types/descriptor.go
+++ b/types/descriptor.go
@@ -50,6 +50,14 @@ type Descriptor struct {
 	ArtifactType string `json:"artifactType,omitempty"`
 }
 
+// annotationVal returns a value from the annotations, or an empty string if unset.
+func (d Descriptor) annotationVal(key string) string {
+	if d.Annotations == nil {
+		return ""
+	}
+	return d.Annotations[key]
+}
+
 // Copy returns a copy of the descriptor
 func (d Descriptor) Copy() Descriptor {
 	d2 := d

--- a/types/layout.go
+++ b/types/layout.go
@@ -14,6 +14,15 @@
 
 package types
 
+import (
+	"slices"
+	"time"
+
+	digest "github.com/sudo-bmitch/oci-digest"
+
+	"github.com/olareg/olareg/internal/reproducible"
+)
+
 const (
 	// LayoutVersion is the supported release of the OCI Layout file definition.
 	LayoutVersion = "1.0.0"
@@ -23,4 +32,268 @@ const (
 type Layout struct {
 	// Version is the implemented OCI Layout version in a given directory.
 	Version string `json:"imageLayoutVersion"`
+}
+
+// LayoutIndex is an extended Index with added fields for the index.json file.
+type LayoutIndex struct {
+	Index
+
+	// History is a map of tags to a slice of history entries known for that tag.
+	History map[string][]LayoutHistory `json:"org.olareg.history,omitempty"`
+
+	// childManifests is used to recursively include child manifests from nested indexes.
+	childManifests []Descriptor
+}
+
+type LayoutHistory struct {
+	Time       time.Time  `json:"time"`
+	Deleted    bool       `json:"deleted,omitempty"`
+	Descriptor Descriptor `json:"descriptor"`
+}
+
+type layoutIndexConf struct {
+	children []Descriptor
+}
+
+type LayoutIndexOpt func(*layoutIndexConf)
+
+// LayoutWithChildren is used to specify child descriptors to move from the embedded index to childManifest descriptor list.
+func LayoutWithChildren(children []Descriptor) LayoutIndexOpt {
+	return func(ic *layoutIndexConf) {
+		ic.children = append(ic.children, children...)
+	}
+}
+
+// AddChildren is used by store implementations to track descriptors from nested manifests (in a child index).
+func (li *LayoutIndex) AddChildren(children []Descriptor) {
+	li.childManifests = append(li.childManifests, children...)
+}
+
+// Copy returns a deep copy of the index to avoid data races
+func (li LayoutIndex) Copy() LayoutIndex {
+	li2 := li
+	li2.Index = li.Index.Copy()
+	// deep copy childManifests
+	li2.childManifests = make([]Descriptor, len(li.childManifests))
+	for im := range li.childManifests {
+		li2.childManifests[im] = li.childManifests[im].Copy()
+	}
+	// deep copy the history
+	li2.History = make(map[string][]LayoutHistory)
+	for tag := range li.History {
+		li2.History[tag] = make([]LayoutHistory, len(li.History[tag]))
+		for ih := range li.History[tag] {
+			li2.History[tag][ih] = li.History[tag][ih]
+			li2.History[tag][ih].Descriptor = li.History[tag][ih].Descriptor.Copy()
+		}
+	}
+	return li2
+}
+
+// AddDesc adds an entry to the LayoutIndex with deduplication.
+// A timestamp is added to the inserted descriptor if not already set.
+// If the descriptor exists as a child, it is removed from the child entries.
+// Alternate references to a tag or referrers response are removed.
+// If a descriptor exists but a tag or referrer annotation is being added, an existing descriptor will be updated.
+// This method ignores and may lose unrecognized fields and annotations.
+// The "WithChildren" option moves matching descriptors without annotations to child manifest list.
+func (li *LayoutIndex) AddDesc(d Descriptor, opts ...LayoutIndexOpt) {
+	conf := layoutIndexConf{children: []Descriptor{}}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+	d = d.Copy() // do not modify the original descriptor (Annotations are a pointer)
+	if d.Annotations == nil {
+		d.Annotations = map[string]string{}
+	}
+	tag := d.Annotations[AnnotRefName]
+	referrer := d.Annotations[AnnotReferrerSubject]
+	// Set creation time on descriptor
+	timestamp := reproducible.TimeNow().Format(time.RFC3339)
+	if d.Annotations[AnnotCreated] == "" {
+		d.Annotations[AnnotCreated] = timestamp
+	}
+
+	// Move entries from WithChildren option to childManifest list.
+	// These are from nested manifests that were pushed before the parent index (`d`).
+	for _, child := range conf.children {
+		if mi := slices.IndexFunc(li.Manifests, func(cur Descriptor) bool {
+			// the digest must match and this cannot have other selectors in the annotations
+			return cur.Digest.Equal(child.Digest) && annotationsEmpty(cur)
+		}); mi >= 0 {
+			li.childManifests = append(li.childManifests, child)
+			li.Manifests = slices.Delete(li.Manifests, mi, mi+1)
+		}
+	}
+
+	// Remove this entry from the child list
+	li.childManifests = slices.DeleteFunc(li.childManifests, func(cur Descriptor) bool { return cur.Digest.Equal(d.Digest) })
+
+	// If this is the referrers response, replace existing response or append this response, and return
+	if referrer != "" {
+		if mi := slices.IndexFunc(li.Manifests, func(cur Descriptor) bool {
+			return cur.annotationVal(AnnotReferrerSubject) == referrer
+		}); mi >= 0 {
+			li.Manifests[mi] = d
+		} else {
+			li.Manifests = append(li.Manifests, d)
+		}
+		return
+	}
+
+	// If this is a tagged entry, untag any previous tag targets to different digests
+	if tag != "" {
+		for mi := len(li.Manifests) - 1; mi >= 0; mi-- {
+			if !li.Manifests[mi].Digest.Equal(d.Digest) && li.Manifests[mi].annotationVal(AnnotRefName) == tag {
+				// remove tag pointing to different digest, make a new descriptor in case there are other annotations
+				if slices.IndexFunc(li.Manifests, func(cur Descriptor) bool {
+					return cur.Digest.Equal(li.Manifests[mi].Digest) && cur.annotationVal(AnnotRefName) != tag
+				}) >= 0 {
+					// another descriptor exists for the same digest, delete this tagged entry
+					li.Manifests = slices.Delete(li.Manifests, mi, mi+1)
+				} else {
+					// untagged this entry (by deleting the annotation)
+					delete(li.Manifests[mi].Annotations, AnnotRefName)
+				}
+				// ensure mi is not past the end of the list after the next `mi--`
+				if mi > len(li.Manifests) {
+					mi = len(li.Manifests)
+				}
+			}
+		}
+	}
+
+	// Search for a compatible entry with the same digest, if tagged find an entry with no tag or a matching tag, else if untagged match any digest
+	// Update only if tag is being added, else return
+	if mi := slices.IndexFunc(li.Manifests, func(cur Descriptor) bool {
+		return cur.Digest.Equal(d.Digest) &&
+			(tag == "" || annotationsEmpty(cur) || cur.annotationVal(AnnotRefName) == tag)
+	}); mi >= 0 {
+		// add tag to an existing entry without a tag
+		if tag != "" && annotationsEmpty(li.Manifests[mi]) {
+			li.Manifests[mi] = d
+		}
+		// all other matches are a noop to avoid changing the created time
+	} else {
+		li.Manifests = append(li.Manifests, d)
+	}
+
+	// track history in the index of tag creates
+	li.addHistory(d, false)
+}
+
+// GetDesc returns a descriptor for a tag or digest, including child descriptors.
+func (li LayoutIndex) GetDesc(arg string) (Descriptor, error) {
+	if RefTagRE.MatchString(arg) {
+		// search for tag
+		mi := slices.IndexFunc(li.Manifests, func(cur Descriptor) bool { return cur.annotationVal(AnnotRefName) == arg })
+		if mi >= 0 {
+			return li.Manifests[mi].Copy(), nil
+		}
+	} else {
+		// else, attempt to parse digest
+		dig, err := digest.Parse(arg)
+		if err != nil {
+			return Descriptor{}, err
+		}
+		// return a matching descriptor, but stripped of any annotations to avoid mixing with tags
+		mi := slices.IndexFunc(li.Manifests, func(cur Descriptor) bool { return cur.Digest.Equal(dig) })
+		if mi >= 0 {
+			return Descriptor{
+				MediaType: li.Manifests[mi].MediaType,
+				Digest:    li.Manifests[mi].Digest,
+				Size:      li.Manifests[mi].Size,
+			}, nil
+		}
+		// search child manifests
+		mi = slices.IndexFunc(li.childManifests, func(cur Descriptor) bool { return cur.Digest.Equal(dig) })
+		if mi >= 0 {
+			return Descriptor{
+				MediaType: li.childManifests[mi].MediaType,
+				Digest:    li.childManifests[mi].Digest,
+				Size:      li.childManifests[mi].Size,
+			}, nil
+		}
+	}
+	return Descriptor{}, ErrNotFound
+}
+
+// RmDesc deletes a descriptor from the index.json.
+// If the provided descriptor is tagged, at least one reference to the digest will be preserved.
+// Otherwise all descriptors matching the digest are deleted.
+func (li *LayoutIndex) RmDesc(d Descriptor) {
+	tag := d.annotationVal(AnnotRefName)
+	if tag != "" {
+		if slices.IndexFunc(li.Manifests, func(cur Descriptor) bool {
+			return cur.Digest.Equal(d.Digest) && cur.annotationVal(AnnotRefName) != tag
+		}) >= 0 {
+			// another descriptor exists for the same digest, delete this tagged descriptor
+			li.Manifests = slices.DeleteFunc(li.Manifests, func(cur Descriptor) bool {
+				if cur.Digest.Equal(d.Digest) && cur.annotationVal(AnnotRefName) == tag {
+					li.addHistory(cur, true)
+					return true
+				}
+				return false
+			})
+		} else {
+			// no other descriptors for the given digest, remove the tag annotation
+			mi := slices.IndexFunc(li.Manifests, func(cur Descriptor) bool { return cur.Digest.Equal(d.Digest) && cur.annotationVal(AnnotRefName) == tag })
+			if mi >= 0 {
+				li.addHistory(li.Manifests[mi], true)
+				delete(li.Manifests[mi].Annotations, AnnotRefName)
+			}
+		}
+	} else {
+		// remove all references to a digest
+		li.childManifests = slices.DeleteFunc(li.childManifests, func(cur Descriptor) bool { return cur.Digest.Equal(d.Digest) })
+		li.Manifests = slices.DeleteFunc(li.Manifests, func(cur Descriptor) bool {
+			if cur.Digest.Equal(d.Digest) {
+				li.addHistory(cur, true)
+				return true
+			}
+			return false
+		})
+	}
+}
+
+func (li *LayoutIndex) addHistory(d Descriptor, del bool) {
+	tag := d.annotationVal(AnnotRefName)
+	if tag == "" {
+		return
+	}
+	timestamp := time.Time{}
+	if !del {
+		if t, err := time.Parse(time.RFC3339, d.annotationVal(AnnotCreated)); err == nil {
+			timestamp = t
+		}
+	}
+	if timestamp.IsZero() {
+		timestamp = reproducible.TimeNow()
+	}
+	dh := Descriptor{
+		MediaType: d.MediaType,
+		Digest:    d.Digest,
+		Size:      d.Size,
+	}
+	if li.History == nil {
+		li.History = map[string][]LayoutHistory{}
+	}
+	li.History[tag] = append(li.History[tag], LayoutHistory{
+		Time:       timestamp,
+		Deleted:    del,
+		Descriptor: dh,
+	})
+}
+
+func annotationsEmpty(d Descriptor) bool {
+	for k := range d.Annotations {
+		switch k {
+		// list annotations excluded from an empty check here
+		case AnnotCreated:
+			// ignore
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/types/layout_test.go
+++ b/types/layout_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/olareg/olareg/internal/reproducible"
 )
 
-func TestIndex(t *testing.T) {
+func TestLayoutIndex(t *testing.T) {
 	t.Parallel()
 	// setup some sample index structs, empty, one entry, three entries, tags, annotations, children
 	tagA, tagB, tagC, tagD, tagIndex := "A", "B", "C", "D", "index"
@@ -116,60 +116,80 @@ func TestIndex(t *testing.T) {
 		Size:        5,
 		Annotations: map[string]string{AnnotRefName: tagIndex},
 	}
-	iZero := Index{}
-	iEmpty := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{},
+	iZero := LayoutIndex{
+		Index: Index{},
 	}
-	iOne := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{descA},
+	iEmpty := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{},
+		},
 	}
-	iOneTag := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{descATag},
+	iOne := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descA},
+		},
 	}
-	iThree := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{descB, descC, descD},
+	iOneTag := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descATag},
+		},
 	}
-	iThreeTag := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{descBTag, descCTag, descDTag},
+	iThree := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descB, descC, descD},
+		},
 	}
-	iIndex := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{descIndex},
+	iThreeTag := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descBTag, descCTag, descDTag},
+		},
 	}
-	iChildren := Index{
-		SchemaVersion:  2,
-		MediaType:      MediaTypeOCI1ManifestList,
-		Manifests:      []Descriptor{descIndexTag},
+	iIndex := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descIndex},
+		},
+	}
+	iChildren := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descIndexTag},
+		},
 		childManifests: []Descriptor{descB, descC, descD},
 	}
-	iChildrenAdd := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{descIndexTag},
+	iChildrenAdd := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descIndexTag},
+		},
 	}
 	iChildrenAdd.AddChildren([]Descriptor{descB, descC, descD})
-	iSubject := Index{
-		SchemaVersion: 2,
-		MediaType:     MediaTypeOCI1ManifestList,
-		Manifests:     []Descriptor{descATag, descBTag, descCSubj, descDSubj},
+	iSubject := LayoutIndex{
+		Index: Index{
+			SchemaVersion: 2,
+			MediaType:     MediaTypeOCI1ManifestList,
+			Manifests:     []Descriptor{descATag, descBTag, descCSubj, descDSubj},
+		},
 	}
 
 	t.Run("GetDesc", func(t *testing.T) {
 		t.Parallel()
 		tt := []struct {
 			name       string
-			i          Index
+			i          LayoutIndex
 			arg        string
 			expectDesc Descriptor
 			expectErr  error
@@ -412,7 +432,7 @@ func TestIndex(t *testing.T) {
 		t.Parallel()
 		tt := []struct {
 			name       string
-			i          Index
+			i          LayoutIndex
 			key, val   string
 			expectDesc Descriptor
 			expectErr  error
@@ -510,11 +530,12 @@ func TestIndex(t *testing.T) {
 	})
 }
 
-func TestAddDesc(t *testing.T) {
+func TestLayoutAddDesc(t *testing.T) {
 	// set a persistent time that will be in all new descriptors
-	t.Setenv(reproducible.EpocEnv, fmt.Sprintf("%d", time.Now().UTC().Unix()))
+	timeNow := time.Now().UTC().Truncate(time.Second)
+	timestamp := timeNow.Format(time.RFC3339)
+	t.Setenv(reproducible.EpocEnv, fmt.Sprintf("%d", timeNow.Unix()))
 	reproducible.TimeProcEnv()
-	timestamp := reproducible.TimeNow().Format(time.RFC3339)
 	// setup some sample index structs, empty, one entry, three entries, tags, annotations, children
 	tagA, tagB, tagC, tagD, tagIndex := "A", "B", "C", "D", "index"
 	digA, err := digest.FromString("A")
@@ -630,11 +651,11 @@ func TestAddDesc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate digest: %v", err)
 	}
-	// descIndex := Descriptor{
-	// 	MediaType: MediaTypeOCI1ManifestList,
-	// 	Digest:    digIndex,
-	// 	Size:      5,
-	// }
+	descIndex := Descriptor{
+		MediaType: MediaTypeOCI1ManifestList,
+		Digest:    digIndex,
+		Size:      5,
+	}
 	descIndexTag := Descriptor{
 		MediaType:   MediaTypeOCI1ManifestList,
 		Digest:      digIndex,
@@ -644,75 +665,115 @@ func TestAddDesc(t *testing.T) {
 	_ = tagD
 	tt := []struct {
 		name string
-		iIn  Index
+		iIn  LayoutIndex
 		dAdd Descriptor
-		opts []IndexOpt
-		iOut Index
+		opts []LayoutIndexOpt
+		iOut LayoutIndex
 	}{
 		{
 			name: "Zero Add A",
-			iIn:  Index{},
+			iIn:  LayoutIndex{},
 			dAdd: descA,
-			iOut: Index{
-				Manifests: []Descriptor{descATime},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime},
+				},
 			},
 		},
 		{
 			name: "A Add A",
-			iIn: Index{
-				Manifests: []Descriptor{descATime},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime},
+				},
 			},
 			dAdd: descA,
-			iOut: Index{
-				Manifests: []Descriptor{descATime},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime},
+				},
 			},
 		},
 		{
 			name: "A tag Add A",
-			iIn: Index{
-				Manifests: []Descriptor{descATag},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag},
+				},
 			},
 			dAdd: descA,
-			iOut: Index{
-				Manifests: []Descriptor{descATag},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag},
+				},
 			},
 		},
 		{
 			name: "A Add B",
-			iIn: Index{
-				Manifests: []Descriptor{descATime},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime},
+				},
 			},
 			dAdd: descB,
-			iOut: Index{
-				Manifests: []Descriptor{descATime, descBTime},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime, descBTime},
+				},
 			},
 		},
 		{
 			name: "ABC Add tag to B",
-			iIn: Index{
-				Manifests: []Descriptor{descATime, descB, descC},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime, descB, descC},
+				},
 			},
 			dAdd: descBTag,
-			iOut: Index{
-				Manifests: []Descriptor{descATime, descBTag, descC},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime, descBTag, descC},
+				},
+				History: map[string][]LayoutHistory{
+					tagB: {
+						{
+							Time:       timeNow,
+							Descriptor: descB,
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "ABC children Add tag to child B",
-			iIn: Index{
-				Manifests:      []Descriptor{descIndexTag},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descIndexTag},
+				},
 				childManifests: []Descriptor{descA, descB, descC},
 			},
 			dAdd: descBTag,
-			iOut: Index{
-				Manifests:      []Descriptor{descIndexTag, descBTag},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descIndexTag, descBTag},
+				},
 				childManifests: []Descriptor{descA, descC},
+				History: map[string][]LayoutHistory{
+					tagB: {
+						{
+							Time:       timeNow,
+							Descriptor: descB,
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "ABC tag replace A tag digest",
-			iIn: Index{
-				Manifests: []Descriptor{descATag, descBTag, descCTag},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag, descBTag, descCTag},
+				},
 			},
 			dAdd: Descriptor{
 				MediaType:   MediaTypeOCI1Manifest,
@@ -720,19 +781,35 @@ func TestAddDesc(t *testing.T) {
 				Size:        2,
 				Annotations: map[string]string{AnnotRefName: tagA},
 			},
-			iOut: Index{
-				Manifests: []Descriptor{descATime, descBTag, descCTag, {
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA2,
-					Size:        2,
-					Annotations: map[string]string{AnnotRefName: tagA, AnnotCreated: timestamp},
-				}},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime, descBTag, descCTag, {
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digA2,
+						Size:        2,
+						Annotations: map[string]string{AnnotRefName: tagA, AnnotCreated: timestamp},
+					}},
+				},
+				History: map[string][]LayoutHistory{
+					tagA: {
+						{
+							Time: timeNow,
+							Descriptor: Descriptor{
+								MediaType: MediaTypeOCI1Manifest,
+								Digest:    digA2,
+								Size:      2,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "ABC subject Add replacement subject to A",
-			iIn: Index{
-				Manifests: []Descriptor{descATag, descBTag, descCSubj},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag, descBTag, descCSubj},
+				},
 			},
 			dAdd: Descriptor{
 				MediaType:   MediaTypeOCI1Manifest,
@@ -740,25 +817,39 @@ func TestAddDesc(t *testing.T) {
 				Size:        1,
 				Annotations: map[string]string{AnnotReferrerSubject: digA.String()},
 			},
-			iOut: Index{
-				Manifests: []Descriptor{descATag, descBTag, {
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digD,
-					Size:        1,
-					Annotations: map[string]string{AnnotReferrerSubject: digA.String(), AnnotCreated: timestamp},
-				}},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag, descBTag, {
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digD,
+						Size:        1,
+						Annotations: map[string]string{AnnotReferrerSubject: digA.String(), AnnotCreated: timestamp},
+					}},
+				},
 			},
 		},
 		{
 			name: "ABCD Add IndexTag with Children BCD",
-			iIn: Index{
-				Manifests: []Descriptor{descATime, descBTime, descCTime, descDTime},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime, descBTime, descCTime, descDTime},
+				},
 			},
 			dAdd: descIndexTag,
-			opts: []IndexOpt{IndexWithChildren([]Descriptor{descB, descC, descD})},
-			iOut: Index{
-				Manifests:      []Descriptor{descATime, descIndexTag},
+			opts: []LayoutIndexOpt{LayoutWithChildren([]Descriptor{descB, descC, descD})},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATime, descIndexTag},
+				},
 				childManifests: []Descriptor{descB, descC, descD},
+				History: map[string][]LayoutHistory{
+					tagIndex: {
+						{
+							Time:       timeNow,
+							Descriptor: descIndex,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -767,15 +858,18 @@ func TestAddDesc(t *testing.T) {
 			ind := tc.iIn.Copy() // clone to avoid modifying a descriptor used in other tests
 			t.Parallel()
 			ind.AddDesc(tc.dAdd, tc.opts...)
-			if !testIndexEqual(ind, tc.iOut) {
+			if !testLayoutEqual(ind, tc.iOut) {
 				t.Errorf("index mismatch, expected %v, received %v", tc.iOut, ind)
 			}
 		})
 	}
 }
 
-func TestRmDesc(t *testing.T) {
-	t.Parallel()
+func TestLayoutRmDesc(t *testing.T) {
+	// set a persistent time that will be in history entries
+	timeNow := time.Now().UTC().Truncate(time.Second)
+	t.Setenv(reproducible.EpocEnv, fmt.Sprintf("%d", timeNow.Unix()))
+	reproducible.TimeProcEnv()
 	// setup some sample index structs, empty, one entry, three entries, tags, annotations, children
 	tagA, tagB, tagC, tagD, tagIndex := "A", "B", "C", "D", "index"
 	_, _ = tagD, tagIndex
@@ -834,16 +928,16 @@ func TestRmDesc(t *testing.T) {
 		Size:        1,
 		Annotations: map[string]string{AnnotRefName: tagC},
 	}
-	descCSubj := Descriptor{
-		MediaType:   MediaTypeOCI1Manifest,
-		Digest:      digC,
-		Size:        1,
-		Annotations: map[string]string{AnnotReferrerSubject: digA.String()},
-	}
-	digD, err := digest.FromString("D")
-	if err != nil {
-		t.Fatalf("failed to generate digest: %v", err)
-	}
+	// descCSubj := Descriptor{
+	// 	MediaType:   MediaTypeOCI1Manifest,
+	// 	Digest:      digC,
+	// 	Size:        1,
+	// 	Annotations: map[string]string{AnnotReferrerSubject: digA.String()},
+	// }
+	// digD, err := digest.FromString("D")
+	// if err != nil {
+	// 	t.Fatalf("failed to generate digest: %v", err)
+	// }
 	// descD := Descriptor{
 	// 	MediaType: MediaTypeOCI1Manifest,
 	// 	Digest:    digD,
@@ -855,12 +949,12 @@ func TestRmDesc(t *testing.T) {
 	// 	Size:        1,
 	// 	Annotations: map[string]string{AnnotRefName: tagD},
 	// }
-	descDSubj := Descriptor{
-		MediaType:   MediaTypeOCI1Manifest,
-		Digest:      digD,
-		Size:        1,
-		Annotations: map[string]string{AnnotReferrerSubject: digB.String()},
-	}
+	// descDSubj := Descriptor{
+	// 	MediaType:   MediaTypeOCI1Manifest,
+	// 	Digest:      digD,
+	// 	Size:        1,
+	// 	Annotations: map[string]string{AnnotReferrerSubject: digB.String()},
+	// }
 	digIndex, err := digest.FromString("index")
 	if err != nil {
 		t.Fatalf("failed to generate digest: %v", err)
@@ -878,147 +972,187 @@ func TestRmDesc(t *testing.T) {
 	}
 	tt := []struct {
 		name string
-		iIn  Index
+		iIn  LayoutIndex
 		dRm  Descriptor
-		iOut Index
+		iOut LayoutIndex
 	}{
 		{
 			name: "Zero Rm A",
-			iIn:  Index{},
+			iIn:  LayoutIndex{},
 			dRm:  descA,
-			iOut: Index{},
+			iOut: LayoutIndex{},
 		},
 		{
 			name: "A Rm B",
-			iIn: Index{
-				Manifests: []Descriptor{descA},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descA},
+				},
 			},
 			dRm: descB,
-			iOut: Index{
-				Manifests: []Descriptor{descA},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descA},
+				},
 			},
 		},
 		{
 			name: "A Rm A",
-			iIn: Index{
-				Manifests: []Descriptor{descA},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descA},
+				},
 			},
 			dRm: descA,
-			iOut: Index{
-				Manifests: []Descriptor{},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{},
+				},
 			},
 		},
 		{
 			// this test is descriptor order dependent
 			name: "A,ATag,A2Tag Rm ATag",
-			iIn: Index{
-				Manifests: []Descriptor{descA, {
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagA},
-				}, {
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagA + "2"},
-				}},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descA, {
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digA,
+						Size:        1,
+						Annotations: map[string]string{AnnotRefName: tagA},
+					}, {
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digA,
+						Size:        1,
+						Annotations: map[string]string{AnnotRefName: tagA + "2"},
+					}},
+				},
 			},
 			dRm: descATag,
-			iOut: Index{
-				Manifests: []Descriptor{descA, {
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagA + "2"},
-				}},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descA, {
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digA,
+						Size:        1,
+						Annotations: map[string]string{AnnotRefName: tagA + "2"},
+					}},
+				},
+				History: map[string][]LayoutHistory{
+					tagA: {
+						{
+							Time:       timeNow,
+							Deleted:    true,
+							Descriptor: descA,
+						},
+					},
+				},
 			},
 		},
 		{
 			// this test is descriptor order dependent
 			name: "A2Tag,ATag,A Rm ATag",
-			iIn: Index{
-				Manifests: []Descriptor{{
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagA},
-				}, {
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagA + "2"},
-				}, descA},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{{
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digA,
+						Size:        1,
+						Annotations: map[string]string{AnnotRefName: tagA},
+					}, {
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digA,
+						Size:        1,
+						Annotations: map[string]string{AnnotRefName: tagA + "2"},
+					}, descA},
+				},
 			},
 			dRm: descATag,
-			iOut: Index{
-				Manifests: []Descriptor{{
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digA,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagA + "2"},
-				}, descA},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{{
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digA,
+						Size:        1,
+						Annotations: map[string]string{AnnotRefName: tagA + "2"},
+					}, descA},
+				},
+				History: map[string][]LayoutHistory{
+					tagA: {
+						{
+							Time:       timeNow,
+							Deleted:    true,
+							Descriptor: descA,
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "ABC Tag Rm B",
-			iIn: Index{
-				Manifests: []Descriptor{descATag, descBTag, descCTag},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag, descBTag, descCTag},
+				},
 			},
 			dRm: descB,
-			iOut: Index{
-				Manifests: []Descriptor{descATag, descCTag},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag, descCTag},
+				},
+				History: map[string][]LayoutHistory{
+					tagB: {
+						{
+							Time:       timeNow,
+							Deleted:    true,
+							Descriptor: descB,
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "ABC child Rm B",
-			iIn: Index{
-				Manifests:      []Descriptor{descIndexTag},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descIndexTag},
+				},
 				childManifests: []Descriptor{descA, descB, descC},
 			},
 			dRm: descB,
-			iOut: Index{
-				Manifests:      []Descriptor{descIndexTag},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descIndexTag},
+				},
 				childManifests: []Descriptor{descA, descC},
 			},
 		},
 		{
 			name: "ABC Tag Rm B Tag",
-			iIn: Index{
-				Manifests: []Descriptor{descATag, {
-					MediaType:   MediaTypeOCI1Manifest,
-					Digest:      digB,
-					Size:        1,
-					Annotations: map[string]string{AnnotRefName: tagB},
-				}, descCTag},
+			iIn: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag, {
+						MediaType:   MediaTypeOCI1Manifest,
+						Digest:      digB,
+						Size:        1,
+						Annotations: map[string]string{AnnotRefName: tagB},
+					}, descCTag},
+				},
 			},
 			dRm: descBTag,
-			iOut: Index{
-				Manifests: []Descriptor{descATag, descB, descCTag},
-			},
-		},
-		{
-			name: "ABC Tag Rm A by tag",
-			iIn: Index{
-				Manifests: []Descriptor{descATag, descBTag, descCTag},
-			},
-			dRm: Descriptor{
-				Annotations: map[string]string{AnnotRefName: tagA},
-			},
-			iOut: Index{
-				Manifests: []Descriptor{descBTag, descCTag},
-			},
-		},
-		{
-			name: "ABCD Subject Rm C by subject",
-			iIn: Index{
-				Manifests: []Descriptor{descATag, descBTag, descCSubj, descDSubj},
-			},
-			dRm: Descriptor{
-				Annotations: map[string]string{AnnotReferrerSubject: digA.String()},
-			},
-			iOut: Index{
-				Manifests: []Descriptor{descATag, descBTag, descDSubj},
+			iOut: LayoutIndex{
+				Index: Index{
+					Manifests: []Descriptor{descATag, descB, descCTag},
+				},
+				History: map[string][]LayoutHistory{
+					tagB: {
+						{
+							Time:       timeNow,
+							Deleted:    true,
+							Descriptor: descB,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1026,7 +1160,7 @@ func TestRmDesc(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tc.iIn.RmDesc(tc.dRm)
-			if !testIndexEqual(tc.iIn, tc.iOut) {
+			if !testLayoutEqual(tc.iIn, tc.iOut) {
 				t.Errorf("index mismatch, expected %v, received %v", tc.iOut, tc.iIn)
 			}
 		})
@@ -1057,10 +1191,11 @@ func testDescEqual(a, b Descriptor) bool {
 	return true
 }
 
-func testIndexEqual(a, b Index) bool {
+func testLayoutEqual(a, b LayoutIndex) bool {
 	if len(a.Manifests) != len(b.Manifests) ||
 		len(a.childManifests) != len(b.childManifests) ||
 		len(a.Annotations) != len(b.Annotations) ||
+		len(a.History) != len(b.History) ||
 		a.ArtifactType != b.ArtifactType {
 		return false
 	}
@@ -1096,6 +1231,19 @@ func testIndexEqual(a, b Index) bool {
 		vB, ok := b.Annotations[k]
 		if !ok || vA != vB {
 			return false
+		}
+	}
+	for tag := range a.History {
+		if len(a.History[tag]) != len(b.History[tag]) {
+			return false
+		}
+		for i, hA := range a.History[tag] {
+			hB := b.History[tag][i]
+			if hA.Deleted != hB.Deleted ||
+				!hA.Time.Equal(hB.Time) ||
+				!testDescEqual(hA.Descriptor, hB.Descriptor) {
+				return false
+			}
 		}
 	}
 	return true

--- a/types/manifest.go
+++ b/types/manifest.go
@@ -18,11 +18,8 @@ import (
 	"encoding/json"
 	"maps"
 	"slices"
-	"time"
 
 	digest "github.com/sudo-bmitch/oci-digest"
-
-	"github.com/olareg/olareg/internal/reproducible"
 )
 
 // Index references manifests for various platforms.
@@ -44,9 +41,6 @@ type Index struct {
 
 	// Annotations contains arbitrary metadata for the image index.
 	Annotations map[string]string `json:"annotations,omitempty"`
-
-	// childManifests is used to recursively include child manifests from nested indexes.
-	childManifests []Descriptor
 }
 
 // Manifest defines an OCI image
@@ -74,34 +68,12 @@ type Manifest struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-type indexConf struct {
-	children []Descriptor
-}
-
-type IndexOpt func(*indexConf)
-
-// IndexWithChildren is used by [Index.AddDesc] to specify child descriptors to move from Manifest to childManifest descriptor list.
-func IndexWithChildren(children []Descriptor) IndexOpt {
-	return func(ic *indexConf) {
-		ic.children = append(ic.children, children...)
-	}
-}
-
-// AddChildren is used by store implementations to track descriptors from nested manifests (in a child index).
-func (i *Index) AddChildren(children []Descriptor) {
-	i.childManifests = append(i.childManifests, children...)
-}
-
 // Copy returns a deep copy of the index to avoid data races
 func (i Index) Copy() Index {
 	i2 := i
 	i2.Manifests = make([]Descriptor, len(i.Manifests))
 	for im := range i.Manifests {
 		i2.Manifests[im] = i.Manifests[im].Copy()
-	}
-	i2.childManifests = make([]Descriptor, len(i.childManifests))
-	for im := range i.childManifests {
-		i2.childManifests[im] = i.childManifests[im].Copy()
 	}
 	if i.Subject != nil {
 		d := i.Subject.Copy()
@@ -112,46 +84,6 @@ func (i Index) Copy() Index {
 		maps.Copy(i2.Annotations, i.Annotations)
 	}
 	return i2
-}
-
-// GetDesc returns a descriptor for a tag or digest, including child descriptors.
-func (i Index) GetDesc(arg string) (Descriptor, error) {
-	var dZero Descriptor
-	if len(i.Manifests) == 0 {
-		return dZero, ErrNotFound
-	}
-	if RefTagRE.MatchString(arg) {
-		// search for tag
-		mi := slices.IndexFunc(i.Manifests, func(cur Descriptor) bool { return annotationEqual(cur.Annotations, AnnotRefName, arg) })
-		if mi >= 0 {
-			return i.Manifests[mi].Copy(), nil
-		}
-	} else {
-		// else, attempt to parse digest
-		dig, err := digest.Parse(arg)
-		if err != nil {
-			return dZero, err
-		}
-		// return a matching descriptor, but stripped of any annotations to avoid mixing with tags
-		mi := slices.IndexFunc(i.Manifests, func(cur Descriptor) bool { return cur.Digest.Equal(dig) })
-		if mi >= 0 {
-			return Descriptor{
-				MediaType: i.Manifests[mi].MediaType,
-				Digest:    i.Manifests[mi].Digest,
-				Size:      i.Manifests[mi].Size,
-			}, nil
-		}
-		// fallback to searching child manifests
-		mi = slices.IndexFunc(i.childManifests, func(cur Descriptor) bool { return cur.Digest.Equal(dig) })
-		if mi >= 0 {
-			return Descriptor{
-				MediaType: i.childManifests[mi].MediaType,
-				Digest:    i.childManifests[mi].Digest,
-				Size:      i.childManifests[mi].Size,
-			}, nil
-		}
-	}
-	return dZero, ErrNotFound
 }
 
 // GetByAnnotation finds an entry with a matching annotation.
@@ -168,136 +100,6 @@ func (i *Index) GetByAnnotation(key, val string) (Descriptor, error) {
 		return i.Manifests[mi], nil
 	}
 	return dRet, ErrNotFound
-}
-
-// AddDesc adds an entry to the Index with deduplication.
-// Alternate references to a tag or referrers response are removed.
-// If a descriptor exists but a tag or referrer annotation is being added, an existing descriptor will be updated.
-// If the descriptor exists as a child, it is removed from the child entries.
-// This method ignores and may lose unrecognized fields and annotations.
-// The "WithChildren" option moves matching descriptors without annotations to child manifest list.
-func (i *Index) AddDesc(d Descriptor, opts ...IndexOpt) {
-	conf := indexConf{children: []Descriptor{}}
-	for _, opt := range opts {
-		opt(&conf)
-	}
-	d = d.Copy() // do not modify the original descriptor (Annotations are a pointer)
-	if d.Annotations == nil {
-		d.Annotations = map[string]string{}
-	}
-	// Set creation time on descriptor
-	d.Annotations[AnnotCreated] = reproducible.TimeNow().Format(time.RFC3339)
-	// extract tag and referrer details if set
-	tag := d.Annotations[AnnotRefName]
-	referrer := d.Annotations[AnnotReferrerSubject]
-
-	// Move entries from WithChildren option to childManifest list.
-	// These are from nested manifests that were pushed before the parent index (`d`).
-	for _, child := range conf.children {
-		if mi := slices.IndexFunc(i.Manifests, func(cur Descriptor) bool {
-			// the digest must match and this cannot have other selectors in the annotations
-			return cur.Digest.Equal(child.Digest) && annotationsEmpty(cur.Annotations)
-		}); mi >= 0 {
-			i.childManifests = append(i.childManifests, child)
-			i.Manifests = slices.Delete(i.Manifests, mi, mi+1)
-		}
-	}
-
-	// Remove this entry from the child list
-	i.childManifests = slices.DeleteFunc(i.childManifests, func(cur Descriptor) bool { return cur.Digest.Equal(d.Digest) })
-
-	// If this is the referrers response, replace existing response or append this response, and return
-	if referrer != "" {
-		if mi := slices.IndexFunc(i.Manifests, func(cur Descriptor) bool {
-			return annotationEqual(cur.Annotations, AnnotReferrerSubject, referrer)
-		}); mi >= 0 {
-			i.Manifests[mi] = d
-		} else {
-			i.Manifests = append(i.Manifests, d)
-		}
-		return
-	}
-
-	// If this is a tagged entry, untag any previous tag targets to different digests
-	if tag != "" {
-		for mi := len(i.Manifests) - 1; mi >= 0; mi-- {
-			if !i.Manifests[mi].Digest.Equal(d.Digest) && annotationEqual(i.Manifests[mi].Annotations, AnnotRefName, tag) {
-				// remove tag pointing to different digest, make a new descriptor in case there are other annotations
-				i.RmDesc(Descriptor{
-					MediaType: i.Manifests[mi].MediaType,
-					Digest:    i.Manifests[mi].Digest,
-					Size:      i.Manifests[mi].Size,
-					Annotations: map[string]string{
-						AnnotRefName: tag,
-					},
-				})
-				// ensure mi is not past the end of the list after the next `mi--`
-				if mi > len(i.Manifests) {
-					mi = len(i.Manifests)
-				}
-			}
-		}
-	}
-
-	// Search for a compatible entry with the same digest, if tagged find an entry with no tag or a matching tag, else if untagged match any digest
-	// Update only if tag is being added, else return
-	if mi := slices.IndexFunc(i.Manifests, func(cur Descriptor) bool {
-		return cur.Digest.Equal(d.Digest) &&
-			(tag == "" || annotationsEmpty(cur.Annotations) || annotationEqual(cur.Annotations, AnnotRefName, tag))
-	}); mi >= 0 {
-		// add tag to an existing entry without a tag
-		if tag != "" && annotationsEmpty(i.Manifests[mi].Annotations) {
-			i.Manifests[mi] = d
-		}
-		// all other matches are a noop to avoid changing the created time
-	} else {
-		i.Manifests = append(i.Manifests, d)
-	}
-
-	// TODO: track history in the index of tag create/delete
-}
-
-// RmDesc deletes a descriptor from the index.
-// If the digest is set, but not a tag or referrer annotation, all references to the digest are deleted.
-// If the tag is set, the specific digest is untagged if the digest is provided, otherwise all descriptors with the tag are deleted.
-// If the referrer annotation is set, all descriptors pointing to the referrer are deleted.
-// If the digest is unset, and the tag and referrer annotations are unset, no action is performed.
-func (i *Index) RmDesc(d Descriptor) {
-	tag := ""
-	referrer := ""
-	if d.Annotations != nil {
-		tag = d.Annotations[AnnotRefName]
-		referrer = d.Annotations[AnnotReferrerSubject]
-	}
-	switch {
-	case tag == "" && referrer == "" && !d.Digest.IsZero():
-		// delete all references to a digest
-		i.childManifests = slices.DeleteFunc(i.childManifests, func(cur Descriptor) bool { return cur.Digest.Equal(d.Digest) })
-		i.Manifests = slices.DeleteFunc(i.Manifests, func(cur Descriptor) bool { return cur.Digest.Equal(d.Digest) })
-	case tag != "" && d.Digest.IsZero():
-		// remove tags
-		i.Manifests = slices.DeleteFunc(i.Manifests, func(cur Descriptor) bool { return annotationEqual(cur.Annotations, AnnotRefName, tag) })
-	case tag != "" && !d.Digest.IsZero():
-		// delete a specific tag, but leave one descriptor pointing to the digest
-		mi := slices.IndexFunc(i.Manifests, func(cur Descriptor) bool {
-			return cur.Digest.Equal(d.Digest) && annotationEqual(cur.Annotations, AnnotRefName, tag)
-		})
-		if mi < 0 {
-			break
-		}
-		if slices.IndexFunc(i.Manifests, func(cur Descriptor) bool {
-			return cur.Digest.Equal(d.Digest) && !annotationEqual(cur.Annotations, AnnotRefName, tag)
-		}) >= 0 {
-			// another descriptor exists for the same digest, delete this tagged entry
-			i.Manifests = slices.Delete(i.Manifests, mi, mi+1)
-		} else {
-			// untagged this entry (by deleting the annotation)
-			delete(i.Manifests[mi].Annotations, AnnotRefName)
-		}
-	case referrer != "":
-		// remove referrer response
-		i.Manifests = slices.DeleteFunc(i.Manifests, func(cur Descriptor) bool { return annotationEqual(cur.Annotations, AnnotReferrerSubject, referrer) })
-	}
 }
 
 type referrerParse struct {
@@ -341,12 +143,4 @@ func ManifestReferrerDescriptor(raw []byte, d Descriptor) (Descriptor, Descripto
 	}
 	rd.Annotations = referrer.Annotations
 	return subject, rd, nil
-}
-
-func annotationEqual(annotations map[string]string, key, value string) bool {
-	return annotations != nil && annotations[key] == value
-}
-
-func annotationsEmpty(annotations map[string]string) bool {
-	return len(annotations) == 0 || (len(annotations) == 1 && annotations[AnnotCreated] != "")
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This tracks tag history in a custom `index.json` field. Future updates will add an API to query the tag history. The history contents are considered an internal feature, and experimental (subject to change without warning). This should only be considered stable after the API is provided and OCI releases a matching spec for the API.

To keep the upstream `Index` manifest clean, these new fields were added to `LayoutIndex` that embeds an Index.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make test
```

And after pushing contents to a filesystem backed registry, the `index.json` file can be observed in the repo to now have a history section with the pushed tags.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add tag history tracking.
- Breaking: methods were moved from `types.Index` to `types.LayoutIndex`.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation updates are included or not applicable (most documentation should be in the olareg.org repo)
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
